### PR TITLE
Update README.zh.md

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -96,7 +96,7 @@ func main() {
 	coreCtx := core.WrapContext(context.Background())
 	reqCall := imService.Messages.Create(coreCtx, &im.MessageCreateReqBody{
 		ReceiveId: "ou_a11d2bcc7d852afbcaf37e5b3ad01f7e",
-		Content:   `{"text":"<at user_id="ou_a11d2bcc7d852afbcaf37e5b3ad01f7e">Tom</at> test content"}`,
+		Content:   `{"text":"<at user_id=\"ou_a11d2bcc7d852afbcaf37e5b3ad01f7e\">Tom</at> test content"}`,
 		MsgType:   "text",
 	})
 	reqCall.SetReceiveIdType("open_id")


### PR DESCRIPTION
直接使用 `README.zh.md` 中的案例会报错
```json
{
  Code: 230001,
  Msg: "Your request contains an invalid request parameter, ext=invalid message content",
  Err: {

  }
}
```

原因是因为消息内容 json 中的双引号没有转义的问题，所以修改 `README.zh.md` 添加 '\' 转义