### PR TITLE
Update larkim.MessageText

### DIFF
--- a/service/im/v1/ext_model.go
+++ b/service/im/v1/ext_model.go
@@ -233,15 +233,11 @@ type MessageText struct {
 }
 
 func NewTextMsgBuilder() *MessageText {
-	m := &MessageText{}
-	m.builder.WriteString("{\"text\":\"")
-	return m
+	return &MessageText{}
 }
 
 func NewMessageTextBuilder() *MessageText {
-	m := &MessageText{}
-	m.builder.WriteString("{\"text\":\"")
-	return m
+	return &MessageText{}
 }
 
 func (t *MessageText) Text(text string) *MessageText {
@@ -251,34 +247,36 @@ func (t *MessageText) Text(text string) *MessageText {
 
 func (t *MessageText) TextLine(text string) *MessageText {
 	t.builder.WriteString(text)
-	t.builder.WriteString("\\n")
+	t.builder.WriteString("\n")
 	return t
 }
 
 func (t *MessageText) Line() *MessageText {
-	t.builder.WriteString("\\n")
+	t.builder.WriteString("\n")
 	return t
 }
 
 func (t *MessageText) AtUser(userId, name string) *MessageText {
-	t.builder.WriteString("<at user_id=\\\"")
+	t.builder.WriteString("<at user_id=\"")
 	t.builder.WriteString(userId)
-	t.builder.WriteString("\\\">")
+	t.builder.WriteString("\">")
 	t.builder.WriteString(name)
 	t.builder.WriteString("</at>")
-	return t
 	return t
 }
 
 func (t *MessageText) AtAll() *MessageText {
-	t.builder.WriteString("<at user_id=\\\"all\\\">")
-	t.builder.WriteString("</at>")
+	t.builder.WriteString("<at user_id=\"all\"></at>")
 	return t
 }
 
-func (t *MessageText) Build() string {
-	t.builder.WriteString("\"}")
-	return t.builder.String()
+func (t *MessageText) Build() (string, error) {
+	m := map[string]string{"text": t.builder.String()}
+	bs, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
 }
 
 /**

--- a/service/im/v1/ext_model.go
+++ b/service/im/v1/ext_model.go
@@ -300,7 +300,7 @@ func (m *MessagePost) EnUs(enUs *MessagePostContent) *MessagePost {
 	return m
 }
 
-func (m *MessagePost) JaJs(jaJp *MessagePostContent) *MessagePost {
+func (m *MessagePost) JaJp(jaJp *MessagePostContent) *MessagePost {
 	m.JaJP = jaJp
 	return m
 }


### PR DESCRIPTION
`MessageText` 直接用 `strings.Builder` 构造 json 内容，结果可能是无效的json内容，尤其是当 text 内容包含双引号、换行符、unicode的时候，必须用 `\\\"` 和 `\\\n` 才可以。

所以 `MessageText.Build()` 也应该和其他类型一样，序列化为 json 并返回 `(string, error)`，才更合理。