### PR TITLE
page_token maybe is empty string

### DIFF
--- a/service/wiki/v2/model.go
+++ b/service/wiki/v2/model.go
@@ -2200,7 +2200,7 @@ func (iterator *ListSpaceIterator) Next() (bool, *Space, error) {
 
 	// 为0则拉取数据
 	if iterator.index == 0 || iterator.index >= len(iterator.items) {
-		if iterator.index != 0 && iterator.nextPageToken == nil {
+		if iterator.index != 0 && (iterator.nextPageToken == nil || *iterator.nextPageToken == "") {
 			return false, nil, nil
 		}
 		if iterator.nextPageToken != nil {


### PR DESCRIPTION
抓包发现拉取 wiki 子节点列表时 page_token 返回的是空字符串，导致遍历时出现死循环的现象。