### PR TITLE
修复由于endTime设置为*string导致的数字到字符串自动转换失败问题。

### DIFF
--- a/service/personal_settings/v1/model.go
+++ b/service/personal_settings/v1/model.go
@@ -90,8 +90,6 @@ func NewDepartmentIdBuilder() *DepartmentIdBuilder {
 	return builder
 }
 
-//
-//
 // 示例值：
 func (builder *DepartmentIdBuilder) DepartmentId(departmentId string) *DepartmentIdBuilder {
 	builder.departmentId = departmentId
@@ -99,8 +97,6 @@ func (builder *DepartmentIdBuilder) DepartmentId(departmentId string) *Departmen
 	return builder
 }
 
-//
-//
 // 示例值：
 func (builder *DepartmentIdBuilder) OpenDepartmentId(openDepartmentId string) *DepartmentIdBuilder {
 	builder.openDepartmentId = openDepartmentId
@@ -668,7 +664,7 @@ func (builder *SystemStatusUserOpenParamBuilder) Build() *SystemStatusUserOpenPa
 type SystemStatusUserOpenResultEntity struct {
 	UserId *string `json:"user_id,omitempty"` // 用户ID
 
-	EndTime *string `json:"end_time,omitempty"` // 结束时间，传入的应为秒单位的时间戳，距当前的时间跨度不能超过365天。
+	EndTime *int64 `json:"end_time,omitempty"` // 结束时间，传入的应为秒单位的时间戳，距当前的时间跨度不能超过365天。
 
 	Result *string `json:"result,omitempty"` // 开启结果
 }
@@ -677,7 +673,7 @@ type SystemStatusUserOpenResultEntityBuilder struct {
 	userId     string // 用户ID
 	userIdFlag bool
 
-	endTime     string // 结束时间，传入的应为秒单位的时间戳，距当前的时间跨度不能超过365天。
+	endTime     int64 // 结束时间，传入的应为秒单位的时间戳，距当前的时间跨度不能超过365天。
 	endTimeFlag bool
 
 	result     string // 开启结果
@@ -701,7 +697,7 @@ func (builder *SystemStatusUserOpenResultEntityBuilder) UserId(userId string) *S
 // 结束时间，传入的应为秒单位的时间戳，距当前的时间跨度不能超过365天。
 //
 // 示例值：1665990378
-func (builder *SystemStatusUserOpenResultEntityBuilder) EndTime(endTime string) *SystemStatusUserOpenResultEntityBuilder {
+func (builder *SystemStatusUserOpenResultEntityBuilder) EndTime(endTime int64) *SystemStatusUserOpenResultEntityBuilder {
 	builder.endTime = endTime
 	builder.endTimeFlag = true
 	return builder
@@ -745,7 +741,7 @@ func NewBatchCloseSystemStatusReqBodyBuilder() *BatchCloseSystemStatusReqBodyBui
 
 // 成员列表
 //
-//示例值：ou_53edd3282dbc2fdbe5c593cfa5ce82ab
+// 示例值：ou_53edd3282dbc2fdbe5c593cfa5ce82ab
 func (builder *BatchCloseSystemStatusReqBodyBuilder) UserList(userList []string) *BatchCloseSystemStatusReqBodyBuilder {
 	builder.userList = userList
 	builder.userListFlag = true
@@ -867,7 +863,7 @@ func NewBatchOpenSystemStatusReqBodyBuilder() *BatchOpenSystemStatusReqBodyBuild
 
 // 开启列表
 //
-//示例值：
+// 示例值：
 func (builder *BatchOpenSystemStatusReqBodyBuilder) UserList(userList []*SystemStatusUserOpenParam) *BatchOpenSystemStatusReqBodyBuilder {
 	builder.userList = userList
 	builder.userListFlag = true
@@ -1147,7 +1143,7 @@ func NewPatchSystemStatusReqBodyBuilder() *PatchSystemStatusReqBodyBuilder {
 
 // 系统状态
 //
-//示例值：
+// 示例值：
 func (builder *PatchSystemStatusReqBodyBuilder) SystemStatus(systemStatus *SystemStatus) *PatchSystemStatusReqBodyBuilder {
 	builder.systemStatus = systemStatus
 	builder.systemStatusFlag = true
@@ -1156,7 +1152,7 @@ func (builder *PatchSystemStatusReqBodyBuilder) SystemStatus(systemStatus *Syste
 
 // 需要更新的字段
 //
-//示例值：['TITLE']
+// 示例值：['TITLE']
 func (builder *PatchSystemStatusReqBodyBuilder) UpdateFields(updateFields []string) *PatchSystemStatusReqBodyBuilder {
 	builder.updateFields = updateFields
 	builder.updateFieldsFlag = true


### PR DESCRIPTION
<img width="3840" height="2402" alt="image" src="https://github.com/user-attachments/assets/411736d5-ad9e-4671-9796-b7bc373ef3a1" />

根据[批量开启系统状态文档](https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/batch_open)，请求成功后会返回数字类型的end_time，但源码中的endTime定义为了*string，这导致了正常返回的结果因json.unmarshall的失败而报错。

解决方案：将返回结构体及相关构建函数重新定义为了*int64。

 ♥️ with CLEC.