### PR TITLE
fix: correct reason field type in CreateAppFeedCard response

### DIFF
--- a/service/im/v2/model.go
+++ b/service/im/v2/model.go
@@ -2241,7 +2241,7 @@ type OpenFailedUserAppFeedCardItem struct {
 
 	UserId *string `json:"user_id,omitempty"` // 用户 ID
 
-	Reason *string `json:"reason,omitempty"` // 原因
+	Reason *int `json:"reason,omitempty"` // 原因
 }
 
 type OpenFailedUserAppFeedCardItemBuilder struct {
@@ -2251,7 +2251,7 @@ type OpenFailedUserAppFeedCardItemBuilder struct {
 	userId     string // 用户 ID
 	userIdFlag bool
 
-	reason     string // 原因
+	reason     int // 原因
 	reasonFlag bool
 }
 
@@ -2281,7 +2281,7 @@ func (builder *OpenFailedUserAppFeedCardItemBuilder) UserId(userId string) *Open
 // 原因
 //
 // 示例值：
-func (builder *OpenFailedUserAppFeedCardItemBuilder) Reason(reason string) *OpenFailedUserAppFeedCardItemBuilder {
+func (builder *OpenFailedUserAppFeedCardItemBuilder) Reason(reason int) *OpenFailedUserAppFeedCardItemBuilder {
 	builder.reason = reason
 	builder.reasonFlag = true
 	return builder


### PR DESCRIPTION
The reason field in OpenFailedUserAppFeedCardItem should be int, not string. This matches the actual API response where reason returns numeric values (e.g., 4).

Changed:
- OpenFailedUserAppFeedCardItem.Reason: *string -> *int
- OpenFailedUserAppFeedCardItemBuilder.reason: string -> int
- OpenFailedUserAppFeedCardItemBuilder.Reason() parameter: string -> int


<img width="3918" height="2266" alt="error-image" src="https://github.com/user-attachments/assets/526bc760-79e4-4e4f-a7ec-c312f1376160" />
