### PR TITLE
fix(core): handle nil serializable and config, remove duplicate return

### DIFF
--- a/card/card_test.go
+++ b/card/card_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/larksuite/oapi-sdk-go/v3/core"
-	"github.com/larksuite/oapi-sdk-go/v3/event"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
 )
 
 func TestVerifyUrlOk(t *testing.T) {
@@ -71,10 +71,15 @@ func mockEventReq(token string) *larkevent.EventReq {
 		TenantKey:     "d32004232",
 		Token:         token,
 		Action: &struct {
-			Value    map[string]interface{} `json:"value"`
-			Tag      string                 `json:"tag"`
-			Option   string                 `json:"option"`
-			Timezone string                 `json:"timezone"`
+			Value      map[string]interface{} `json:"value"`
+			Tag        string                 `json:"tag"`
+			Option     string                 `json:"option"`
+			Timezone   string                 `json:"timezone"`
+			Name       string                 `json:"name"`
+			FormValue  map[string]interface{} `json:"form_value"`
+			InputValue string                 `json:"input_value"`
+			Options    []string               `json:"options"`
+			Checked    bool                   `json:"checked"`
 		}{
 			Value: value,
 			Tag:   "button",
@@ -219,10 +224,15 @@ func mockCardAction() *CardAction {
 		OpenMessageID: "om_abcdefg1234567890",
 		TenantKey:     "d32004232",
 		Action: &struct {
-			Value    map[string]interface{} `json:"value"`
-			Tag      string                 `json:"tag"`
-			Option   string                 `json:"option"`
-			Timezone string                 `json:"timezone"`
+			Value      map[string]interface{} `json:"value"`
+			Tag        string                 `json:"tag"`
+			Option     string                 `json:"option"`
+			Timezone   string                 `json:"timezone"`
+			Name       string                 `json:"name"`
+			FormValue  map[string]interface{} `json:"form_value"`
+			InputValue string                 `json:"input_value"`
+			Options    []string               `json:"options"`
+			Checked    bool                   `json:"checked"`
 		}{
 			Value: value,
 			Tag:   "button",
@@ -245,10 +255,15 @@ func TestDoHandleResultCardOk(t *testing.T) {
 			OpenMessageID: "om_abcdefg1234567890",
 			TenantKey:     "d32004232",
 			Action: &struct {
-				Value    map[string]interface{} `json:"value"`
-				Tag      string                 `json:"tag"`
-				Option   string                 `json:"option"`
-				Timezone string                 `json:"timezone"`
+				Value      map[string]interface{} `json:"value"`
+				Tag        string                 `json:"tag"`
+				Option     string                 `json:"option"`
+				Timezone   string                 `json:"timezone"`
+				Name       string                 `json:"name"`
+				FormValue  map[string]interface{} `json:"form_value"`
+				InputValue string                 `json:"input_value"`
+				Options    []string               `json:"options"`
+				Checked    bool                   `json:"checked"`
 			}{
 				Value: value,
 				Tag:   "button",

--- a/core/httpserverext/httpserverext_test.go
+++ b/core/httpserverext/httpserverext_test.go
@@ -20,10 +20,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/larksuite/oapi-sdk-go/v3/card"
-	"github.com/larksuite/oapi-sdk-go/v3/core"
+	larkcard "github.com/larksuite/oapi-sdk-go/v3/card"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
-	"github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 )
 
 func TestStartHttpServer(t *testing.T) {
@@ -66,10 +66,15 @@ func mockRequest() *http.Request {
 		TenantKey:     "d32004232",
 		Token:         token,
 		Action: &struct {
-			Value    map[string]interface{} `json:"value"`
-			Tag      string                 `json:"tag"`
-			Option   string                 `json:"option"`
-			Timezone string                 `json:"timezone"`
+			Value      map[string]interface{} `json:"value"`
+			Tag        string                 `json:"tag"`
+			Option     string                 `json:"option"`
+			Timezone   string                 `json:"timezone"`
+			Name       string                 `json:"name"`
+			FormValue  map[string]interface{} `json:"form_value"`
+			InputValue string                 `json:"input_value"`
+			Options    []string               `json:"options"`
+			Checked    bool                   `json:"checked"`
 		}{
 			Value: value,
 			Tag:   "button",

--- a/core/httptransport.go
+++ b/core/httptransport.go
@@ -169,6 +169,15 @@ func doSend(ctx context.Context, rawRequest *http.Request, httpClient HttpClient
 }
 
 func Request(ctx context.Context, req *ApiReq, config *Config, options ...RequestOptionFunc) (*ApiResp, error) {
+	if config == nil {
+		return nil, &IllegalParamError{msg: "config is nil"}
+	}
+	NewHttpClient(config)
+	NewSerialization(config)
+	if config.Logger == nil {
+		NewLogger(config)
+	}
+
 	option := &RequestOption{}
 	for _, optionFunc := range options {
 		optionFunc(option)

--- a/core/reqtranslator.go
+++ b/core/reqtranslator.go
@@ -226,6 +226,9 @@ func (translator *ReqTranslator) payload(body interface{}, serializable Serializ
 	if body == nil {
 		return contentType, nil, nil
 	}
+	if serializable == nil {
+		serializable = &DefaultSerialization{}
+	}
 	bs, err := serializable.Serialize(body)
 	return contentType, bs, err
 }

--- a/service/ext/model.go
+++ b/service/ext/model.go
@@ -31,8 +31,8 @@ type AuthenAccessTokenReqBody struct {
 }
 
 type AuthenAccessTokenReqBodyBuilder struct {
-	grantType string `json:"grant_type,omitempty"`
-	code      string `json:"code,omitempty"`
+	grantType string
+	code      string
 }
 
 func NewAuthenAccessTokenReqBodyBuilder() *AuthenAccessTokenReqBodyBuilder {
@@ -124,8 +124,8 @@ type RefreshAuthenAccessTokenReqBody struct {
 }
 
 type RefreshAuthenAccessTokenReqBodyBuilder struct {
-	grantType    string `json:"grant_type,omitempty"`
-	refreshToken string `json:"refresh_token,omitempty"`
+	grantType    string
+	refreshToken string
 }
 
 func NewRefreshAuthenAccessTokenReqBodyBuilder() *RefreshAuthenAccessTokenReqBodyBuilder {
@@ -263,8 +263,8 @@ type CreateFileReqBody struct {
 }
 
 type CreateFileReqBodyBuilder struct {
-	title string `json:"title,omitempty"`
-	type_ string `json:"type,omitempty"`
+	title string
+	type_ string
 }
 
 func NewCreateFileReqBodyBuilder() *CreateFileReqBodyBuilder {

--- a/service/im/v1/ext_model.go
+++ b/service/im/v1/ext_model.go
@@ -268,7 +268,6 @@ func (t *MessageText) AtUser(userId, name string) *MessageText {
 	t.builder.WriteString(name)
 	t.builder.WriteString("</at>")
 	return t
-	return t
 }
 
 func (t *MessageText) AtAll() *MessageText {


### PR DESCRIPTION

- Add nil check for serializable in payload() to use default serialization
- Add nil check for config in Request() to return error and initialize missing components
- Remove duplicate return statement in AtUser() method
- Update struct tags in model builders to omit JSON fields
- Expand test mock structs to include additional fields
