### PR TITLE
feat(ws): add `WithReconnectCount` client option

### DIFF
--- a/ws/client.go
+++ b/ws/client.go
@@ -75,6 +75,12 @@ func WithAutoReconnect(b bool) ClientOption {
 	}
 }
 
+func WithReconnectCount(n int) ClientOption {
+	return func(cli *Client) {
+		cli.reconnectCount = n
+	}
+}
+
 func WithDomain(domain string) ClientOption {
 	return func(cli *Client) {
 		cli.domain = domain

--- a/ws/client_option_test.go
+++ b/ws/client_option_test.go
@@ -1,0 +1,17 @@
+package ws
+
+import "testing"
+
+func TestWithReconnectCount_SetsValue(t *testing.T) {
+	cli := NewClient("appID", "appSecret", WithReconnectCount(3))
+	if cli.reconnectCount != 3 {
+		t.Fatalf("expected reconnectCount=3, got %d", cli.reconnectCount)
+	}
+}
+
+func TestNewClient_DefaultReconnectCount(t *testing.T) {
+	cli := NewClient("appID", "appSecret")
+	if cli.reconnectCount != -1 {
+		t.Fatalf("expected default reconnectCount=-1, got %d", cli.reconnectCount)
+	}
+}


### PR DESCRIPTION

Add a new functional option to configure the maximum number of automatic
reconnection attempts for the WebSocket client. This provides users with
control over reconnection behavior, allowing them to set a limit or use
the default of unlimited retries (-1).
