### PR TITLE
feat(ws): add WithClientProxy option for explicit proxy configuration

### DIFF
--- a/ws/client.go
+++ b/ws/client.go
@@ -41,6 +41,8 @@ type Client struct {
 	pingInterval      time.Duration // Ping间隔
 	cache             *larkcache.Cache
 	mu                sync.Mutex
+	dialer            *ws.Dialer
+	httpClient        *http.Client
 }
 
 type ClientOption func(cli *Client)
@@ -81,6 +83,32 @@ func WithDomain(domain string) ClientOption {
 	}
 }
 
+func WithClientProxy(proxyUrl string) ClientOption {
+	return func(cli *Client) {
+		if proxyUrl == "" {
+			return
+		}
+		proxy, err := url.Parse(proxyUrl)
+		if err != nil {
+			return
+		}
+
+		cli.dialer.Proxy = http.ProxyURL(proxy)
+
+		var transport *http.Transport
+		if t, ok := http.DefaultTransport.(*http.Transport); ok {
+			transport = t.Clone()
+		} else {
+			transport = &http.Transport{}
+		}
+
+		transport.Proxy = http.ProxyURL(proxy)
+		cli.httpClient = &http.Client{
+			Transport: transport,
+		}
+	}
+}
+
 func NewClient(appId, appSecret string, opts ...ClientOption) *Client {
 	cli := &Client{
 		appID:             appId,
@@ -92,6 +120,11 @@ func NewClient(appId, appSecret string, opts ...ClientOption) *Client {
 		pingInterval:      2 * time.Minute,
 		cache:             larkcache.New(30 * time.Second),
 		domain:            lark.FeishuBaseUrl,
+		dialer: &ws.Dialer{
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: 45 * time.Second,
+		},
+		httpClient: http.DefaultClient,
 	}
 
 	for _, opt := range opts {
@@ -149,7 +182,7 @@ func (c *Client) connect(ctx context.Context) (err error) {
 	connID := u.Query().Get(DeviceID)
 	serviceID := u.Query().Get(ServiceID)
 
-	conn, resp, err := ws.DefaultDialer.Dial(connUrl, nil)
+	conn, resp, err := c.dialer.Dial(connUrl, nil)
 	if err != nil && resp == nil {
 		return
 	}
@@ -249,7 +282,7 @@ func (c *Client) getConnURL(ctx context.Context) (url string, err error) {
 	}
 
 	req.Header.Add("locale", "zh")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
当前版本的 websocket 客户端在建立长链接时，底层默认使用了 ws.DefaultDialer 和 http.DefaultClient。这导致了在某些需要通过代理访问企业内网或外部服务的场景下，开发者无法为 websocket 客户端单独、显式地配置网络代理。

**💡 方案 (Solution)**
在 ws.Client 结构体内维护私有的 dialer 和 httpClient 实例，取代原先的全局单例，避免并发情况下的全局污染。
新增 WithClientProxy(proxyUrl string) 配置项：
- 解析传入的 HTTP 代理地址。
- 将代理应用到 ws.Client 专属的 Dialer 中。
- 深拷贝当前环境下的 http.DefaultTransport（若不存在则初始化基础 Transport），将代理应用其中，并构建专属的 http.Client 以用于获取建连 URL 时的 HTTP 请求。
如果未显式调用 WithClientProxy，默认行为与之前保持一致（支持读取环境变量代理）。

**💻 使用示例 (Example)**
```go
cli := larkws.NewClient(
    os.Getenv("APP_ID"), 
    os.Getenv("APP_SECRET"),
    larkws.WithEventHandler(eventHandler),
    // 显式配置 WebSocket 客户端的网络代理
    larkws.WithClientProxy("http://127.0.0.1:8888"),
)
err := cli.Start(context.Background())
```