### PR TITLE
fix: Fix 32-bit platform compilation issue

### DIFF
--- a/service/drive/v1/api_ext.go
+++ b/service/drive/v1/api_ext.go
@@ -16,10 +16,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 
-	"github.com/larksuite/oapi-sdk-go/v3/core"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
+
+const maxInt = int(^uint(0) >> 1)
 
 func (f *file) ListByIterator(ctx context.Context, req *ListFileReq, options ...larkcore.RequestOptionFunc) (*ListFileIterator, error) {
 	return &ListFileIterator{
@@ -27,7 +28,7 @@ func (f *file) ListByIterator(ctx context.Context, req *ListFileReq, options ...
 		req:      req,
 		listFunc: f.List,
 		options:  options,
-		limit:    math.MaxInt64}, nil
+		limit:    maxInt}, nil
 }
 
 type ListFileIterator struct {


### PR DESCRIPTION
Fix 32-bit platform compilation issue by using platform-dependent max integer value instead of math.MaxInt64