### PR TITLE
fix: 修复多维表格筛选项 isEmpty/isNotEmpty 操作符无法使用的问题

### DIFF
--- a/service/bitable/v1/model.go
+++ b/service/bitable/v1/model.go
@@ -3992,7 +3992,7 @@ type Condition struct {
 
 	Operator *string `json:"operator,omitempty"` // 条件运算符
 
-	Value []string `json:"value,omitempty"` // 目标值
+	Value []string `json:"value"` // 目标值
 }
 
 type ConditionBuilder struct {


### PR DESCRIPTION
Filter.Conditions[].Value 字段的 omitempty 标签导致空数组 [] 无法被序列化, 请求会报错 。 

而飞书 API 要求 isEmpty/isNotEmpty 操作符必须传入空数组 。
- 开放平台文档: https://open.feishu.cn/document/docs/bitable-v1/app-table-record/record-filter-guide
- 文档具体描述: operator为isEmpty或isNotEmpty时，需填空值 []

报错信息:
{
  "code": 9499,
  "error": {
    "log_id": "20260405160759DA6D748745293DC6BDD7",
    "troubleshooter": "排查建议查看(Troubleshooting suggestions): https://open.feishu.cn/search?from=openapi&log_id=20260405160759DA6D748745293DC6BDD7&code=9499&method_id=7301628054955556866"
  },
  "msg": "Missing required parameter: Value. Missing required parameter path: filter.conditions[1].value, Please check and modify accordingly."
}

结论:
移除 omitempty 标签后可正常发送 value:[] , 能正常使用 isEmpty/isNotEmpty筛选项.

优化建议:
如果operator是 isEmpty/isNotEmpty时, 后续底层可以直接去掉value字段的校验, 因为此时value字段无意义.