### PR TITLE
fix: 改用 int64 支持 32 位系统编译

### DIFF
--- a/service/drive/v1/api_ext.go
+++ b/service/drive/v1/api_ext.go
@@ -34,12 +34,12 @@ type ListFileIterator struct {
 	nextPageToken *string
 	items         []*File
 	index         int
-	limit         int
+	limit         int64
 	ctx           context.Context
 	req           *ListFileReq
 	listFunc      func(ctx context.Context, req *ListFileReq, options ...larkcore.RequestOptionFunc) (*ListFileResp, error)
 	options       []larkcore.RequestOptionFunc
-	curlNum       int
+	curlNum       int64
 }
 
 func (iterator *ListFileIterator) Next() (bool, *File, error) {


### PR DESCRIPTION
将 ListFileIterator 的 limit 和 curlNum 改为 int64 以支持 32 位系统编译