### PR TITLE
feat(im/convert): support content_v2 blocks in post message conversion

### DIFF
--- a/channel/normalize/converters.go
+++ b/channel/normalize/converters.go
@@ -3,10 +3,16 @@ package normalize
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/larksuite/oapi-sdk-go/v3/channel/types"
+)
+
+var (
+	atMentionRe = regexp.MustCompile(`<at(\s+)user_id(\s*)=(\s*)"(.*?)">(.*?)</at>`)
+	imageKeyRe  = regexp.MustCompile(`!\[(.*?)\]\(([^)]+)\)`)
 )
 
 // ParseContent parses the message content based on the message type.
@@ -286,9 +292,7 @@ func ParseContent(msgType string, content string) (string, []types.Resource) {
 		var contentStr string
 		var resources []types.Resource
 
-		// For post, the contentMap usually looks like:
-		// { "zh_cn": { "title": "...", "content": [ [ {...} ] ] } }
-		// Find the first value that is a map
+		// Find bodyMap first — the return guarantees bodyMap is non-nil below.
 		var bodyMap map[string]interface{}
 		for _, v := range contentMap {
 			if m, ok := v.(map[string]interface{}); ok {
@@ -296,8 +300,18 @@ func ParseContent(msgType string, content string) (string, []types.Resource) {
 				break
 			}
 		}
-
 		if bodyMap == nil {
+			return "[rich text message]", nil
+		}
+
+		// Choose source: prefer bodyMap["content_v2"], else bodyMap["content"].
+		var sourceParagraphs []interface{}
+		if cv2, ok := bodyMap["content_v2"].([]interface{}); ok && len(cv2) > 0 {
+			sourceParagraphs = cv2
+		} else if cl, ok := bodyMap["content"].([]interface{}); ok {
+			sourceParagraphs = cl
+		}
+		if len(sourceParagraphs) == 0 {
 			return "[rich text message]", nil
 		}
 
@@ -307,69 +321,70 @@ func ParseContent(msgType string, content string) (string, []types.Resource) {
 			lines = append(lines, "")
 		}
 
-		if contentList, ok := bodyMap["content"].([]interface{}); ok {
-			for _, paragraphInterface := range contentList {
-				paragraph, ok := paragraphInterface.([]interface{})
+		for _, paragraphInterface := range sourceParagraphs {
+			paragraph, ok := paragraphInterface.([]interface{})
+			if !ok {
+				continue
+			}
+			var lineParts []string
+			for _, elInterface := range paragraph {
+				el, ok := elInterface.(map[string]interface{})
 				if !ok {
 					continue
 				}
-				var lineParts []string
-				for _, elInterface := range paragraph {
-					el, ok := elInterface.(map[string]interface{})
-					if !ok {
-						continue
-					}
-					tag, _ := el["tag"].(string)
-					text, _ := el["text"].(string)
+				tag, _ := el["tag"].(string)
+				text, _ := el["text"].(string)
 
-					switch tag {
-					case "text":
-						// Simplified style handling
-						lineParts = append(lineParts, text)
-					case "a":
-						href, _ := el["href"].(string)
-						label := text
-						if label == "" {
-							label = href
-						}
-						if href != "" {
-							lineParts = append(lineParts, fmt.Sprintf("[%s](%s)", label, href))
-						} else {
-							lineParts = append(lineParts, label)
-						}
-					case "at":
-						userID, _ := el["user_id"].(string)
-						userName, _ := el["user_name"].(string)
-						if userID == "all" || userID == "all_members" {
-							lineParts = append(lineParts, "@all")
-						} else if userName != "" {
-							lineParts = append(lineParts, "@"+userName)
-						} else {
-							lineParts = append(lineParts, "@"+userID)
-						}
-					case "img":
-						imageKey, _ := el["image_key"].(string)
-						if imageKey != "" {
-							resources = append(resources, types.Resource{Type: "image", FileKey: imageKey})
-							lineParts = append(lineParts, fmt.Sprintf("![image](%s)", imageKey))
-						}
-					case "media":
-						fileKey, _ := el["file_key"].(string)
-						if fileKey != "" {
-							resources = append(resources, types.Resource{Type: "file", FileKey: fileKey})
-							lineParts = append(lineParts, fmt.Sprintf(`<file key="%s"/>`, fileKey))
-						}
-					case "code_block":
-						lang, _ := el["language"].(string)
-						lineParts = append(lineParts, fmt.Sprintf("\n```%s\n%s\n```\n", lang, text))
-					case "hr":
-						lineParts = append(lineParts, "\n---\n")
-					default:
-						lineParts = append(lineParts, text)
+				switch tag {
+				case "md":
+					mdText, mdRes := processMdText(text)
+					lineParts = append(lineParts, mdText)
+					resources = append(resources, mdRes...)
+				case "text":
+					lineParts = append(lineParts, text)
+				case "a":
+					href, _ := el["href"].(string)
+					label := text
+					if label == "" {
+						label = href
 					}
+					if href != "" {
+						lineParts = append(lineParts, fmt.Sprintf("[%s](%s)", label, href))
+					} else {
+						lineParts = append(lineParts, label)
+					}
+				case "at":
+					userID, _ := el["user_id"].(string)
+					userName, _ := el["user_name"].(string)
+					if userID == "all" || userID == "all_members" {
+						lineParts = append(lineParts, "@all")
+					} else if userName != "" {
+						lineParts = append(lineParts, "@"+userName)
+					} else {
+						lineParts = append(lineParts, "@"+userID)
+					}
+				case "img":
+					imageKey, _ := el["image_key"].(string)
+					if imageKey != "" {
+						resources = append(resources, types.Resource{Type: "image", FileKey: imageKey})
+						lineParts = append(lineParts, fmt.Sprintf("![image](%s)", imageKey))
+					}
+				case "media":
+					fileKey, _ := el["file_key"].(string)
+					if fileKey != "" {
+						resources = append(resources, types.Resource{Type: "file", FileKey: fileKey})
+						lineParts = append(lineParts, fmt.Sprintf(`<file key="%s"/>`, fileKey))
+					}
+				case "code_block":
+					lang, _ := el["language"].(string)
+					lineParts = append(lineParts, fmt.Sprintf("\n```%s\n%s\n```\n", lang, text))
+				case "hr":
+					lineParts = append(lineParts, "\n---\n")
+				default:
+					lineParts = append(lineParts, text)
 				}
-				lines = append(lines, strings.Join(lineParts, ""))
 			}
+			lines = append(lines, strings.Join(lineParts, ""))
 		}
 
 		contentStr = strings.Join(lines, "\n")
@@ -469,4 +484,52 @@ func extractPostPlainText(blocks []interface{}) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// processMdText post-processes raw markdown text from an "md" element.
+// It splits the text by fenced code block delimiters (```) and only
+// applies transformations (at-mention replacement, image key extraction)
+// to text segments outside of properly paired code blocks. Unclosed fences
+// are treated as outside-code-block text.
+func processMdText(text string) (string, []types.Resource) {
+	var resources []types.Resource
+	parts := strings.Split(text, "```")
+	total := len(parts)
+	for i, part := range parts {
+		// Determine if this segment is inside a paired code block.
+		// Odd-index segments are inside code blocks, UNLESS it's the last
+		// segment of an even-length split (meaning the final ``` is unclosed).
+		isInside := (i%2 == 1)
+		if isInside && total%2 == 0 && i == total-1 {
+			isInside = false
+		}
+		if !isInside {
+			// Outside code block: apply at-mention replacement.
+			part = atMentionRe.ReplaceAllStringFunc(part, func(match string) string {
+				submatch := atMentionRe.FindStringSubmatch(match)
+				if len(submatch) >= 6 {
+					userID := submatch[4]
+					name := submatch[5]
+					if userID == "all" || userID == "all_members" {
+						return "@all"
+					}
+					if name != "" {
+						return "@" + name
+					}
+					return "@" + userID
+				}
+				return match
+			})
+
+			// Extract image keys from ![...](key) patterns.
+			for _, imgMatch := range imageKeyRe.FindAllStringSubmatch(part, -1) {
+				if len(imgMatch) >= 3 && imgMatch[2] != "" {
+					resources = append(resources, types.Resource{Type: "image", FileKey: imgMatch[2]})
+				}
+			}
+		}
+		// Inside code block: preserve as-is.
+		parts[i] = part
+	}
+	return strings.Join(parts, "```"), resources
 }

--- a/channel/normalize/converters_test.go
+++ b/channel/normalize/converters_test.go
@@ -141,6 +141,63 @@ func TestParseContent(t *testing.T) {
 			wantContent:  "[interactive card]",
 			wantResource: nil,
 		},
+		// --- content_v2 tests ---
+		{
+			name:         "post with content_v2 (md tag)",
+			msgType:      "post",
+			content:      `{"zh_cn":{"content_v2":[[{"tag":"md","text":"Hello **world**"}]]}}`,
+			wantContent:  "Hello **world**",
+			wantResource: nil,
+		},
+		{
+			name:         "post without content_v2 (richtext fallback)",
+			msgType:      "post",
+			content:      `{"zh_cn":{"title":"Title","content":[[{"tag":"text","text":"Hello"}]]}}`,
+			wantContent:  "**Title**\n\nHello",
+			wantResource: nil,
+		},
+		{
+			name:         "post with empty content_v2 array (richtext fallback)",
+			msgType:      "post",
+			content:      `{"zh_cn":{"title":"Fallback","content":[[{"tag":"text","text":"richtext"}]],"content_v2":[]}}`,
+			wantContent:  "**Fallback**\n\nrichtext",
+			wantResource: nil,
+		},
+		{
+			name:         "post with content_v2 type exception (string, not array)",
+			msgType:      "post",
+			content:      `{"zh_cn":{"title":"Fallback","content":[[{"tag":"text","text":"richtext"}]],"content_v2":"not_an_array"}}`,
+			wantContent:  "**Fallback**\n\nrichtext",
+			wantResource: nil,
+		},
+		{
+			name:         "post content_v2 with @mention replacement",
+			msgType:      "post",
+			content:      `{"zh_cn":{"content_v2":[[{"tag":"md","text":"<at user_id=\"ou_123\">小明</at> hello"}]]}}`,
+			wantContent:  "@小明 hello",
+			wantResource: nil,
+		},
+		{
+			name:         "post content_v2 with @all mention",
+			msgType:      "post",
+			content:      `{"zh_cn":{"content_v2":[[{"tag":"md","text":"<at user_id=\"all\">所有人</at> hello"}]]}}`,
+			wantContent:  "@all hello",
+			wantResource: nil,
+		},
+		{
+			name:         "post content_v2 with image extraction",
+			msgType:      "post",
+			content:      `{"zh_cn":{"content_v2":[[{"tag":"md","text":"Look: ![image](img_key_123)"}]]}}`,
+			wantContent:  "Look: ![image](img_key_123)",
+			wantResource: []types.Resource{{Type: "image", FileKey: "img_key_123"}},
+		},
+		{
+			name:         "post content_v2 code block boundary protection",
+			msgType:      "post",
+			content:      `{"zh_cn":{"content_v2":[[{"tag":"md","text":"Before\n` + "```" + `go\n<at user_id=\"ou_1\">name</at>\n![image](k)\n` + "```" + `\nAfter"}]]}}`,
+			wantContent:  "Before\n```go\n<at user_id=\"ou_1\">name</at>\n![image](k)\n```\nAfter",
+			wantResource: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/channel/normalize/markdown.go
+++ b/channel/normalize/markdown.go
@@ -2,8 +2,6 @@ package normalize
 
 import (
 	"encoding/json"
-	"regexp"
-	"strings"
 
 	"github.com/larksuite/oapi-sdk-go/v3/channel/types"
 )
@@ -26,103 +24,12 @@ type postElement struct {
 	UserName string `json:"user_name,omitempty"`
 }
 
-// SimpleMarkdownToPost converts a basic markdown string to Lark Post JSON string.
-// It supports paragraphs and links in the format [text](url).
+// SimpleMarkdownToPost wraps raw markdown into a Lark Post JSON string using
+// the "md" tag so the Feishu client renders it natively.
 func SimpleMarkdownToPost(title, markdown string, mentions []types.Mention) (string, error) {
-	lines := strings.Split(markdown, "\n")
-	content := make([][]postElement, 0, len(lines))
+	content := make([][]postElement, 0, 2)
 
-	linkRegex := regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
-	atRegex := regexp.MustCompile(`<at user_id="([^"]+)">(.*?)</at>`)
-
-	for _, line := range lines {
-		line = strings.TrimRight(line, "\r")
-
-		var paragraph []postElement
-
-		// Find all matches for both links and at tags
-		linkMatches := linkRegex.FindAllStringSubmatchIndex(line, -1)
-		atMatches := atRegex.FindAllStringSubmatchIndex(line, -1)
-
-		// Combine and sort matches by starting index
-		type matchInfo struct {
-			start, end int
-			mType      string // "link" or "at"
-			indices    []int
-		}
-		var allMatches []matchInfo
-		for _, m := range linkMatches {
-			allMatches = append(allMatches, matchInfo{m[0], m[1], "link", m})
-		}
-		for _, m := range atMatches {
-			allMatches = append(allMatches, matchInfo{m[0], m[1], "at", m})
-		}
-
-		// Sort matches by start index
-		for i := 0; i < len(allMatches); i++ {
-			for j := i + 1; j < len(allMatches); j++ {
-				if allMatches[i].start > allMatches[j].start {
-					allMatches[i], allMatches[j] = allMatches[j], allMatches[i]
-				}
-			}
-		}
-
-		lastIndex := 0
-		for _, match := range allMatches {
-			start, end := match.start, match.end
-
-			// Prevent overlapping matches
-			if start < lastIndex {
-				continue
-			}
-
-			if start > lastIndex {
-				paragraph = append(paragraph, postElement{
-					Tag:  "text",
-					Text: line[lastIndex:start],
-				})
-			}
-
-			if match.mType == "link" {
-				textStart, textEnd := match.indices[2], match.indices[3]
-				hrefStart, hrefEnd := match.indices[4], match.indices[5]
-				paragraph = append(paragraph, postElement{
-					Tag:  "a",
-					Text: line[textStart:textEnd],
-					Href: line[hrefStart:hrefEnd],
-				})
-			} else if match.mType == "at" {
-				userIDStart, userIDEnd := match.indices[2], match.indices[3]
-				userNameStart, userNameEnd := match.indices[4], match.indices[5]
-				paragraph = append(paragraph, postElement{
-					Tag:      "at",
-					UserID:   line[userIDStart:userIDEnd],
-					UserName: line[userNameStart:userNameEnd],
-				})
-			}
-
-			lastIndex = end
-		}
-
-		if lastIndex < len(line) {
-			paragraph = append(paragraph, postElement{
-				Tag:  "text",
-				Text: line[lastIndex:],
-			})
-		}
-
-		// Keep empty lines as empty text elements to maintain paragraph spacing
-		if len(paragraph) == 0 {
-			paragraph = append(paragraph, postElement{
-				Tag:  "text",
-				Text: " ", // Use space instead of empty string to bypass omitempty and Feishu empty check
-			})
-		}
-
-		content = append(content, paragraph)
-	}
-
-	// Prepend mentions
+	// Prepend mentions as at elements for notification delivery.
 	if len(mentions) > 0 {
 		atElements := ComposePostMentionElements(mentions)
 		if len(atElements) > 0 {
@@ -130,9 +37,12 @@ func SimpleMarkdownToPost(title, markdown string, mentions []types.Mention) (str
 			for _, el := range atElements {
 				first = append(first, el, postElement{Tag: "text", Text: " "})
 			}
-			content = append([][]postElement{first}, content...)
+			content = append(content, first)
 		}
 	}
+
+	// Wrap raw markdown in md tag.
+	content = append(content, []postElement{{Tag: "md", Text: markdown}})
 
 	post := postContent{
 		ZhCn: postLanguage{


### PR DESCRIPTION
## Summary

Support content_v2 blocks in IM post message conversion, and switch Markdown post generation to use the native md tag. This improves compatibility for Markdown rendering, mentions, image resource extraction, and code block preservation.

## Changes

- Prefer content_v2 when parsing post messages, with fallback to legacy content
- Add md element handling for mention replacement, image resource extraction, and code block boundary protection
- Update SimpleMarkdownToPost to wrap raw Markdown in an md tag while preserving mention notification elements
- Add unit tests for content_v2, fallback behavior, mentions, image extraction, and code block handling

## Test Plan

- [x] Unit tests passed: go test ./channel/normalize
- [ ] Manually verified lark xxx command works