### PR TITLE
fix(ws): guard client config updates

### DIFF
--- a/ws/client.go
+++ b/ws/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	reconnectInterval       time.Duration // 重连间隔
 	pingInterval            time.Duration // Ping间隔
 	cache                   *larkcache.Cache
+	configMu                sync.RWMutex
 	mu                      sync.Mutex
 	onReady                 func()
 	onError                 func(err error)
@@ -280,15 +281,17 @@ func (c *Client) reconnect(ctx context.Context) (err error) {
 		c.onReconnecting()
 	}
 
+	reconnectNonce, reconnectCount, reconnectInterval := c.reconnectConfigSnapshot()
+
 	// 首次重连随机抖动
-	if c.reconnectNonce > 0 {
+	if reconnectNonce > 0 {
 		rand.Seed(time.Now().UnixNano())
-		num := rand.Intn(c.reconnectNonce * 1000)
+		num := rand.Intn(reconnectNonce * 1000)
 		time.Sleep(time.Duration(num) * time.Millisecond)
 	}
 
-	if c.reconnectCount >= 0 {
-		for i := 0; i < c.reconnectCount; i++ {
+	if reconnectCount >= 0 {
+		for i := 0; i < reconnectCount; i++ {
 			success, err := c.tryConnect(ctx, i)
 			if success {
 				if c.onReconnected != nil {
@@ -299,9 +302,10 @@ func (c *Client) reconnect(ctx context.Context) (err error) {
 			if err != nil {
 				return err
 			}
-			time.Sleep(c.reconnectInterval)
+			_, _, reconnectInterval = c.reconnectConfigSnapshot()
+			time.Sleep(reconnectInterval)
 		}
-		return fmt.Errorf("unable to connect to server after %d retries", c.reconnectCount)
+		return fmt.Errorf("unable to connect to server after %d retries", reconnectCount)
 	} else {
 		i := 0
 		for {
@@ -315,7 +319,8 @@ func (c *Client) reconnect(ctx context.Context) (err error) {
 			if err != nil {
 				return err
 			}
-			time.Sleep(c.reconnectInterval)
+			_, _, reconnectInterval = c.reconnectConfigSnapshot()
+			time.Sleep(reconnectInterval)
 			i += 1
 		}
 	}
@@ -502,8 +507,9 @@ func (c *Client) pingLoop(ctx context.Context) {
 	}()
 
 	for {
-		if c.conn != nil {
-			i, _ := strconv.ParseInt(c.serviceID, 10, 32)
+		connected, serviceID := c.connectionSnapshot()
+		if connected {
+			i, _ := strconv.ParseInt(serviceID, 10, 32)
 			frame := NewPingFrame(int32(i))
 			bs, _ := frame.Marshal()
 
@@ -514,7 +520,7 @@ func (c *Client) pingLoop(ctx context.Context) {
 				c.logger.Debug(ctx, c.fmtLog("ping success")...)
 			}
 		}
-		time.Sleep(c.pingInterval)
+		time.Sleep(c.pingIntervalSnapshot())
 	}
 }
 
@@ -703,10 +709,34 @@ func (c *Client) fmtLog(format string, i ...interface{}) []interface{} {
 }
 
 func (c *Client) configure(conf *ClientConfig) {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+
 	c.reconnectCount = conf.ReconnectCount
 	c.reconnectInterval = time.Duration(conf.ReconnectInterval) * time.Second
 	c.reconnectNonce = conf.ReconnectNonce
 	c.pingInterval = time.Duration(conf.PingInterval) * time.Second
+}
+
+func (c *Client) reconnectConfigSnapshot() (nonce int, count int, interval time.Duration) {
+	c.configMu.RLock()
+	defer c.configMu.RUnlock()
+
+	return c.reconnectNonce, c.reconnectCount, c.reconnectInterval
+}
+
+func (c *Client) pingIntervalSnapshot() time.Duration {
+	c.configMu.RLock()
+	defer c.configMu.RUnlock()
+
+	return c.pingInterval
+}
+
+func (c *Client) connectionSnapshot() (bool, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.conn != nil, c.serviceID
 }
 
 func parseErr(resp *http.Response) error {

--- a/ws/client_test.go
+++ b/ws/client_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
@@ -210,4 +211,19 @@ func TestBuildWSProxyURL(t *testing.T) {
 			t.Fatalf("unexpected proxy url for %s: %s", targetService, proxyURL)
 		}
 	}
+}
+
+func TestPingLoopConfigureRace(t *testing.T) {
+	client := NewClient("app-id", "app-secret")
+	client.pingInterval = time.Nanosecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go client.pingLoop(ctx)
+
+	for i := 0; i < 1000; i++ {
+		client.configure(&ClientConfig{PingInterval: 0})
+	}
+	client.configure(&ClientConfig{PingInterval: 1})
 }


### PR DESCRIPTION
## Summary
- add a dedicated config mutex for WebSocket client config updated by `configure`
- read ping/reconnect settings through snapshots before using them from background loops
- snapshot connection state before `pingLoop` reads `serviceID`, without holding the connection mutex while writing to the socket

This intentionally does not reuse the existing `c.mu` for `configure`: `connect` holds `c.mu` while calling `getConnURL`, and `getConnURL` can call `configure` when the bootstrap endpoint returns `ClientConfig`. Reusing `c.mu` there would risk deadlocking that path.

Fixes #188
Fixes #189

## Tests
- `go test -race ./ws -run TestPingLoopConfigureRace -count=1`
- `go test -race ./ws -count=1`
- `go test ./ws -count=1`
- `go test ./... -count=1`
- `git diff --check`
