### PR TITLE
[codex] support registration app addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,27 @@
-# 飞书开放接口SDK/Feishu OpenPlatform Server SDK
+# Feishu OpenPlatform Server SDK
 
-旨在让开发者便捷的调用飞书开放API、处理订阅的事件、处理服务端推送的卡片行为等。
+[English](./README.md) | [Simplified Chinese](./README.zh.md)
 
 Feishu Open Platform offers a series of server-side atomic APIs to achieve diverse functionalities. However, actual coding requires additional work, such as obtaining and maintaining access tokens, encrypting and decrypting data, and verifying request signatures. Furthermore, the lack of semantic descriptions for function calls and type system support can increase coding burdens.
 
-To address these issues, Feishu Open Platform has developed the Open Interface SDK, which incorporates all lengthy logic processes, provides a comprehensive type system, and offers a semantic programming interface to enhance the coding experience.
+To address these issues, Feishu Open Platform has developed the Open Interface SDK, which incorporates these lengthy logic processes, provides a comprehensive type system, and offers a semantic programming interface to improve the coding experience.
 
-## 介绍文档 Introduction Documents
+## Introduction Documents
 
-- [开发前准备（安装） / Preparations before development(Install SDK)](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/preparations)
-- [调用服务端 API / Calling Server-side APIs](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/calling-server-side-apis)
-- [处理事件订阅 / Handle Events](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/handle-events)
-- [处理卡片回调 / Handle Card Callbacks](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/handle-callback)
-- [常见问题 / SDK FAQs](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/faq)
+- [Preparations before development (Install SDK)](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/preparations)
+- [Calling Server-side APIs](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/calling-server-side-apis)
+- [Handle Events](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/handle-events)
+- [Handle Card Callbacks](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/handle-callback)
+- [SDK FAQs](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/faq)
 
-## 高级封装 Channel 模块 / Channel Module
-
-SDK 提供了一个基于 WebSocket 和 API Client 封装的 Channel 模块。它将飞书机器人接入过程中的事件监听、消息归一化、发送流式回复、上传媒体等操作进行了高层封装，让开发者能更专注业务逻辑。
+## Channel Module
 
 The SDK provides a `Channel` module built on top of WebSocket and the API Client. It encapsulates event listening, message normalization, streaming replies, and media uploads, allowing developers to focus purely on business logic.
 
-- [Channel 模块文档 / Channel Module Documentation (中文)](./doc/channel.zh.md)
 - [Channel Module Documentation (English)](./doc/channel.md)
+- [Channel Module Documentation (Chinese)](./doc/channel.zh.md)
 
-## 一键创建应用 / One-Click App Registration
-
-SDK 提供了 `registration.RegisterApp` 方法，基于 OAuth 2.0 Device Authorization Grant（RFC 8628）协议实现一键创建应用。调用后会返回一个验证链接，用户在飞书/Lark 中打开链接或扫码完成授权后，即可自动注册应用并获取 `App ID` 与 `App Secret`，无需手动前往开发者后台创建。
+## One-Click App Registration
 
 The SDK provides `registration.RegisterApp` for one-click app creation based on OAuth 2.0 Device Authorization Grant (RFC 8628). It returns a verification URL that users can open in Feishu/Lark or render as a QR code. After authorization, the app is created automatically and the SDK returns the `App ID` and `App Secret`.
 
@@ -77,67 +73,119 @@ func main() {
 }
 ```
 
-### `registration.RegisterApp` 参数 / Parameters
+### Custom Scopes, Events, Callbacks, And Updating An Existing App
 
-| 参数 Parameter | 描述 Description | 类型 Type | 必填 Required | 默认值 Default |
+When creating an app, use `Options.Addons` to incrementally request scopes, event subscriptions, and callbacks on top of the platform base template. The values are pre-filled into the confirmation page after the user opens the QR code URL and take effect after confirmation. `Options.CreateOnly=true` only allows creating a new app. `Options.AppID` starts the update flow for an existing app.
+
+```go
+_, err := registration.RegisterApp(ctx, &registration.Options{
+	Addons: &registration.AppAddons{
+		Scopes: registration.AppAddonsScopes{
+			Tenant: []string{"im:message:send_as_bot"},
+			User:   []string{"calendar:calendar:read"},
+		},
+		Events: registration.AppAddonsEvents{
+			Items: registration.AppAddonsEventItems{
+				Tenant: []string{"im.message.receive_v1"},
+			},
+		},
+		Callbacks: registration.AppAddonsCallbacks{
+			Items: []string{"card.action.trigger"},
+		},
+	},
+	CreateOnly: true,
+	OnQRCode: func(info *registration.QRCodeInfo) {
+		fmt.Println(info.URL)
+	},
+})
+if err != nil {
+	panic(err)
+}
+
+_, err = registration.RegisterApp(ctx, &registration.Options{
+	AppID: "cli_xxx",
+	Addons: &registration.AppAddons{
+		Scopes: registration.AppAddonsScopes{
+			Tenant: []string{"drive:drive.metadata:readonly"},
+		},
+	},
+	OnQRCode: func(info *registration.QRCodeInfo) {
+		fmt.Println(info.URL)
+	},
+})
+if err != nil {
+	panic(err)
+}
+```
+
+Notes: `Addons` is additive only and cannot remove config from the base template. The SDK validates shape and non-empty strings, but does not validate whether scope, event, or callback names exist.
+
+### `registration.RegisterApp` Parameters
+
+| Parameter | Description | Type | Required | Default |
 | ---- | ---- | ---- | ---- | ---- |
-| `ctx` | 控制注册流程的超时与取消；取消 `context` 会终止轮询。 Controls timeout and cancellation for the registration flow; canceling the `context` stops polling. | `context.Context` | 是 Yes | - |
-| `Options.Source` | 来源标识，会拼入二维码 URL 的 `source` 参数，格式为 `go-sdk/{source}`。 Source identifier appended to the QR URL as `go-sdk/{source}`. | `string` | 否 No | `go-sdk` |
-| `Options.Domain` | 自定义飞书认证域名，支持传完整前缀，如 `https://accounts.feishu.cn`。 Custom Feishu accounts domain. A full base URL such as `https://accounts.feishu.cn` is supported. | `string` | 否 No | `https://accounts.feishu.cn` |
-| `Options.LarkDomain` | 自定义 Lark 认证域名；检测到 `tenant_brand=lark` 时自动切换。 Custom Lark accounts domain used when `tenant_brand=lark` is detected. | `string` | 否 No | `https://accounts.larksuite.com` |
-| `Options.AppPreset` | 预设应用信息，仅用于初始化创建页；用户仍可在页面修改，最终以页面提交为准。 Pre-filled app creation values; users can still edit them on the page. | `*registration.AppPreset` | 否 No | - |
-| `Options.AppPreset.Avatar` | 应用头像 URL，支持 1-6 个；第一个默认选中。传原始 URL，SDK 会编码。头像展示、图片可访问性、GIF 取帧等由创建页处理。 App avatar URLs, 1-6 entries; first entry is selected by default. Pass raw URLs and the SDK encodes them. Page-side display rules are handled by the app creation page. | `[]string` | 否 No | - |
-| `Options.AppPreset.Name` | 应用名称，支持 `{user}` 占位符；传原始值，SDK 会编码。 App name with `{user}` placeholder support; pass raw value and the SDK encodes it. | `string` | 否 No | - |
-| `Options.AppPreset.Desc` | 应用描述，支持 `{user}` 占位符；传原始值，SDK 会编码。 App description with `{user}` placeholder support; pass raw value and the SDK encodes it. | `string` | 否 No | - |
-| `Options.OnQRCode` | 验证链接就绪时的回调，参数为 `{ URL, ExpireIn }`。可直接展示链接，或将其渲染为二维码供用户扫码。 Callback invoked when the verification URL is ready. | `func(info *registration.QRCodeInfo)` | 是 Yes | - |
-| `Options.OnStatusChange` | 轮询状态变化回调，参数为 `{ Status, Interval }`。`Status` 可能为 `polling`、`slow_down`、`domain_switched`。 Callback for polling status changes. | `func(info *registration.StatusChangeInfo)` | 否 No | - |
+| `ctx` | Controls timeout and cancellation for the registration flow; canceling the `context` stops polling. | `context.Context` | Yes | - |
+| `Options.Source` | Source identifier appended to the QR URL as `go-sdk/{source}`. | `string` | No | `go-sdk` |
+| `Options.Domain` | Custom Feishu accounts domain. A full base URL such as `https://accounts.feishu.cn` is supported. | `string` | No | `https://accounts.feishu.cn` |
+| `Options.LarkDomain` | Custom Lark accounts domain used when `tenant_brand=lark` is detected. | `string` | No | `https://accounts.larksuite.com` |
+| `Options.AppPreset` | Pre-filled app creation values; users can still edit them on the page. | `*registration.AppPreset` | No | - |
+| `Options.AppPreset.Avatar` | App avatar URLs, 1-6 entries; first entry is selected by default. Pass raw URLs and the SDK encodes them. Page-side display rules are handled by the app creation page. | `[]string` | No | - |
+| `Options.AppPreset.Name` | App name with `{user}` placeholder support; pass raw value and the SDK encodes it. | `string` | No | - |
+| `Options.AppPreset.Desc` | App description with `{user}` placeholder support; pass raw value and the SDK encodes it. | `string` | No | - |
+| `Options.Addons` | Incremental scopes, events, and callbacks pre-filled into the confirmation page. | `*registration.AppAddons` | No | - |
+| `Options.Addons.Scopes.Tenant` | App-identity scopes, for example `im:message:send_as_bot`. | `[]string` | No | - |
+| `Options.Addons.Scopes.User` | User-identity scopes, for example `calendar:calendar:read`. | `[]string` | No | - |
+| `Options.Addons.Events.Items.Tenant` | App-identity events, for example `im.message.receive_v1`. | `[]string` | No | - |
+| `Options.Addons.Events.Items.User` | User-identity events, for example `calendar.calendar.event.changed_v4`. | `[]string` | No | - |
+| `Options.Addons.Callbacks.Items` | Callback names, for example `card.action.trigger`. | `[]string` | No | - |
+| `Options.CreateOnly` | When `true`, the landing page only allows creating a new app. When used together with `Options.AppID`, the page gives create-new-app flow precedence. | `bool` | No | `false` |
+| `Options.AppID` | Existing app ID carried as `clientID` in the QR URL for the update flow. | `string` | No | - |
+| `Options.OnQRCode` | Callback invoked when the verification URL is ready. The callback receives `{ URL, ExpireIn }`. | `func(info *registration.QRCodeInfo)` | Yes | - |
+| `Options.OnStatusChange` | Callback for polling status changes. `Status` can be `polling`, `slow_down`, or `domain_switched`. | `func(info *registration.StatusChangeInfo)` | No | - |
 
-### 返回值 / Return Value
+### Return Value
 
-| 字段 Field | 类型 Type | 描述 Description |
+| Field | Type | Description |
 | ---- | ---- | ---- |
-| `ClientID` | `string` | 应用的 `App ID` / App ID |
-| `ClientSecret` | `string` | 应用的 `App Secret` / App Secret |
-| `UserInfo` | `*registration.UserInfo` | 扫码用户信息 / Scanning user info |
-| `UserInfo.OpenID` | `string` | 扫码用户的 `open_id` / User `open_id` |
-| `UserInfo.TenantBrand` | `string` | `"feishu"` 或 `"lark"` / `"feishu"` or `"lark"` |
+| `ClientID` | `string` | App ID |
+| `ClientSecret` | `string` | App Secret |
+| `UserInfo` | `*registration.UserInfo` | Scanning user info |
+| `UserInfo.OpenID` | `string` | User `open_id` |
+| `UserInfo.TenantBrand` | `string` | `"feishu"` or `"lark"` |
 
-### 错误处理 / Error Handling
-
-返回的错误通常可以通过 `errors.As(err, &registration.RegisterAppError)` 获取 `Code` 与 `Description` 字段。更具体的错误类型还包括 `registration.AccessDeniedError` 和 `registration.ExpiredError`。
+### Error Handling
 
 Returned errors usually expose `Code` and `Description` through `registration.RegisterAppError`. More specific types include `registration.AccessDeniedError` and `registration.ExpiredError`.
 
-| `Code` | 描述 Description |
+| `Code` | Description |
 | ---- | ---- |
-| `access_denied` | 用户拒绝授权 / User denied authorization |
-| `expired_token` | 二维码过期或轮询超时 / QR code expired or polling timed out |
-| `invalid_response` | 接口返回缺少必要字段或响应为空 / Response is empty or missing required fields |
+| `access_denied` | User denied authorization |
+| `expired_token` | QR code expired or polling timed out |
+| `invalid_response` | Response is empty or missing required fields |
 
-## 扩展示例
+## Extended Examples
 
-我们还基于 SDK 封装了常用的 API 组合调用及业务场景示例，如：
+We also provide common API composition examples and business scenario examples based on the SDK, such as:
 
-* 消息
-    * [发送文件消息](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/im/send_file.go)
-    * [发送图片消息](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/im/send_image.go)
-* 通讯录
-    * [获取部门下所有用户列表](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/contact/list_user_by_department.go)
-* 多维表格
-    * [创建多维表格同时添加数据表](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/base/create_app_and_tables.go)
-* 电子表格
-    * [复制粘贴某个范围的单元格数据](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/sheets/copy_and_paste_by_range.go)
-    * [下载指定范围单元格的所有素材列表](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/sheets/download_media_by_range.go)
-* 教程
-    * [机器人自动拉群报警](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/quick_start/robot) ([开发教程](https://open.feishu.cn/document/home/message-development-tutorial/introduction))
+* Messages
+    * [Send file messages](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/im/send_file.go)
+    * [Send image messages](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/im/send_image.go)
+* Contacts
+    * [Get all users under a department](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/contact/list_user_by_department.go)
+* Base
+    * [Create a Base app and add tables](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/base/create_app_and_tables.go)
+* Sheets
+    * [Copy and paste a cell range](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/sheets/copy_and_paste_by_range.go)
+    * [Download all media in a cell range](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/sheets/download_media_by_range.go)
+* Tutorials
+    * [Robot alert group automation](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/quick_start/robot) ([development tutorial](https://open.feishu.cn/document/home/message-development-tutorial/introduction))
 
-更多示例可参考：https://github.com/larksuite/oapi-sdk-go-demo
+For more examples, see https://github.com/larksuite/oapi-sdk-go-demo
 
-## 加入交流互助群
+## Community
 
-[单击加入交流互助](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=985nb30c-787a-4fbb-904d-2cf945534078)
+[Join the support group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=985nb30c-787a-4fbb-904d-2cf945534078)
 
 ## License
 
-使用 MIT
-
+MIT

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,191 @@
+# 飞书开放接口 SDK
+
+[English](./README.md) | [简体中文](./README.zh.md)
+
+飞书开放平台提供了一系列服务端原子 API，用于实现多种业务能力。但在实际编码中，开发者通常还需要处理 access token 获取与维护、数据加解密、请求签名校验等通用逻辑；同时，缺少语义化调用方式和类型系统支持也会增加编码负担。
+
+为了解决这些问题，飞书开放平台提供了开放接口 SDK。SDK 封装了冗长的通用逻辑，提供完善的类型系统和语义化编程接口，帮助开发者提升编码体验。
+
+## 介绍文档
+
+- [开发前准备（安装 SDK）](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/preparations)
+- [调用服务端 API](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/calling-server-side-apis)
+- [处理事件订阅](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/handle-events)
+- [处理卡片回调](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/golang-sdk-guide/handle-callback)
+- [常见问题](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/server-side-sdk/faq)
+
+## 高级封装 Channel 模块
+
+SDK 提供了一个基于 WebSocket 和 API Client 封装的 Channel 模块。它将飞书机器人接入过程中的事件监听、消息归一化、发送流式回复、上传媒体等操作进行了高层封装，让开发者能更专注业务逻辑。
+
+- [Channel 模块文档（中文）](./doc/channel.zh.md)
+- [Channel Module Documentation (English)](./doc/channel.md)
+
+## 一键创建应用
+
+SDK 提供了 `registration.RegisterApp` 方法，基于 OAuth 2.0 Device Authorization Grant（RFC 8628）协议实现一键创建应用。调用后会返回一个验证链接，用户在飞书/Lark 中打开链接或扫码完成授权后，即可自动注册应用并获取 `App ID` 与 `App Secret`，无需手动前往开发者后台创建。
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	"github.com/larksuite/oapi-sdk-go/v3/scene/registration"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	result, err := registration.RegisterApp(ctx, &registration.Options{
+		OnQRCode: func(info *registration.QRCodeInfo) {
+			fmt.Printf("open or scan this url: %s\n", info.URL)
+			fmt.Printf("the link expires in %d seconds\n", info.ExpireIn)
+		},
+		OnStatusChange: func(info *registration.StatusChangeInfo) {
+			// status: polling | slow_down | domain_switched
+			fmt.Printf("registration status: %s", info.Status)
+			if info.Interval > 0 {
+				fmt.Printf(", next poll after %d seconds", info.Interval)
+			}
+			fmt.Println()
+		},
+	})
+	if err != nil {
+		var regErr *registration.RegisterAppError
+		if errors.As(err, &regErr) {
+			fmt.Printf("register app failed: code=%s, description=%s\n", regErr.Code, regErr.Description)
+			return
+		}
+		panic(err)
+	}
+
+	fmt.Println("App ID:", result.ClientID)
+	fmt.Println("App Secret:", result.ClientSecret)
+
+	client := lark.NewClient(result.ClientID, result.ClientSecret)
+	_ = client
+}
+```
+
+### 自定义权限、事件、回调与更新已有应用
+
+创建应用时，可通过 `Options.Addons` 在平台基础模板上增量申请权限、事件订阅和回调。这些配置会预填到用户扫码后的确认页中，用户确认后生效。`Options.CreateOnly=true` 时，页面只允许创建新应用；传入 `Options.AppID` 时，页面会进入更新已有应用配置的确认流程。
+
+```go
+_, err := registration.RegisterApp(ctx, &registration.Options{
+	Addons: &registration.AppAddons{
+		Scopes: registration.AppAddonsScopes{
+			Tenant: []string{"im:message:send_as_bot"},
+			User:   []string{"calendar:calendar:read"},
+		},
+		Events: registration.AppAddonsEvents{
+			Items: registration.AppAddonsEventItems{
+				Tenant: []string{"im.message.receive_v1"},
+			},
+		},
+		Callbacks: registration.AppAddonsCallbacks{
+			Items: []string{"card.action.trigger"},
+		},
+	},
+	CreateOnly: true,
+	OnQRCode: func(info *registration.QRCodeInfo) {
+		fmt.Println(info.URL)
+	},
+})
+if err != nil {
+	panic(err)
+}
+
+_, err = registration.RegisterApp(ctx, &registration.Options{
+	AppID: "cli_xxx",
+	Addons: &registration.AppAddons{
+		Scopes: registration.AppAddonsScopes{
+			Tenant: []string{"drive:drive.metadata:readonly"},
+		},
+	},
+	OnQRCode: func(info *registration.QRCodeInfo) {
+		fmt.Println(info.URL)
+	},
+})
+if err != nil {
+	panic(err)
+}
+```
+
+注意：`Addons` 仅支持增量叠加，不支持删除基础模板中的配置；SDK 只校验数据形状和非空字符串，不校验权限点、事件或回调名称是否存在。
+
+### `registration.RegisterApp` 参数
+
+| 参数 | 描述 | 类型 | 必填 | 默认值 |
+| ---- | ---- | ---- | ---- | ---- |
+| `ctx` | 控制注册流程的超时与取消；取消 `context` 会终止轮询。 | `context.Context` | 是 | - |
+| `Options.Source` | 来源标识，会拼入二维码 URL 的 `source` 参数，格式为 `go-sdk/{source}`。 | `string` | 否 | `go-sdk` |
+| `Options.Domain` | 自定义飞书认证域名，支持传完整前缀，如 `https://accounts.feishu.cn`。 | `string` | 否 | `https://accounts.feishu.cn` |
+| `Options.LarkDomain` | 自定义 Lark 认证域名；检测到 `tenant_brand=lark` 时自动切换。 | `string` | 否 | `https://accounts.larksuite.com` |
+| `Options.AppPreset` | 预设应用信息，仅用于初始化创建页；用户仍可在页面修改，最终以页面提交为准。 | `*registration.AppPreset` | 否 | - |
+| `Options.AppPreset.Avatar` | 应用头像 URL，支持 1-6 个；第一个默认选中。传原始 URL，SDK 会编码。头像展示、图片可访问性、GIF 取帧等由创建页处理。 | `[]string` | 否 | - |
+| `Options.AppPreset.Name` | 应用名称，支持 `{user}` 占位符；传原始值，SDK 会编码。 | `string` | 否 | - |
+| `Options.AppPreset.Desc` | 应用描述，支持 `{user}` 占位符；传原始值，SDK 会编码。 | `string` | 否 | - |
+| `Options.Addons` | 增量权限、事件、回调配置，预填到扫码后的确认页，用户确认后生效。 | `*registration.AppAddons` | 否 | - |
+| `Options.Addons.Scopes.Tenant` | 应用身份权限列表，如 `im:message:send_as_bot`。 | `[]string` | 否 | - |
+| `Options.Addons.Scopes.User` | 用户身份权限列表，如 `calendar:calendar:read`。 | `[]string` | 否 | - |
+| `Options.Addons.Events.Items.Tenant` | 应用身份事件列表，如 `im.message.receive_v1`。 | `[]string` | 否 | - |
+| `Options.Addons.Events.Items.User` | 用户身份事件列表，如 `calendar.calendar.event.changed_v4`。 | `[]string` | 否 | - |
+| `Options.Addons.Callbacks.Items` | 回调列表，如 `card.action.trigger`。 | `[]string` | 否 | - |
+| `Options.CreateOnly` | 为 `true` 时落地页仅允许创建新应用；与 `Options.AppID` 同时传入时，页面侧优先走新建流程。 | `bool` | 否 | `false` |
+| `Options.AppID` | 已有应用的 App ID；传入后会作为二维码 URL 的 `clientID` 参数，用于更新已有应用配置。 | `string` | 否 | - |
+| `Options.OnQRCode` | 验证链接就绪时的回调，参数为 `{ URL, ExpireIn }`。可直接展示链接，或将其渲染为二维码供用户扫码。 | `func(info *registration.QRCodeInfo)` | 是 | - |
+| `Options.OnStatusChange` | 轮询状态变化回调，参数为 `{ Status, Interval }`。`Status` 可能为 `polling`、`slow_down`、`domain_switched`。 | `func(info *registration.StatusChangeInfo)` | 否 | - |
+
+### 返回值
+
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| `ClientID` | `string` | 应用的 `App ID` |
+| `ClientSecret` | `string` | 应用的 `App Secret` |
+| `UserInfo` | `*registration.UserInfo` | 扫码用户信息 |
+| `UserInfo.OpenID` | `string` | 扫码用户的 `open_id` |
+| `UserInfo.TenantBrand` | `string` | `"feishu"` 或 `"lark"` |
+
+### 错误处理
+
+返回的错误通常可以通过 `errors.As(err, &registration.RegisterAppError)` 获取 `Code` 与 `Description` 字段。更具体的错误类型还包括 `registration.AccessDeniedError` 和 `registration.ExpiredError`。
+
+| `Code` | 描述 |
+| ---- | ---- |
+| `access_denied` | 用户拒绝授权 |
+| `expired_token` | 二维码过期或轮询超时 |
+| `invalid_response` | 接口返回缺少必要字段或响应为空 |
+
+## 扩展示例
+
+我们还基于 SDK 封装了常用的 API 组合调用及业务场景示例，如：
+
+* 消息
+    * [发送文件消息](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/im/send_file.go)
+    * [发送图片消息](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/im/send_image.go)
+* 通讯录
+    * [获取部门下所有用户列表](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/contact/list_user_by_department.go)
+* 多维表格
+    * [创建多维表格同时添加数据表](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/base/create_app_and_tables.go)
+* 电子表格
+    * [复制粘贴某个范围的单元格数据](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/sheets/copy_and_paste_by_range.go)
+    * [下载指定范围单元格的所有素材列表](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/composite_api/sheets/download_media_by_range.go)
+* 教程
+    * [机器人自动拉群报警](https://github.com/larksuite/oapi-sdk-go-demo/blob/main/quick_start/robot)（[开发教程](https://open.feishu.cn/document/home/message-development-tutorial/introduction)）
+
+更多示例可参考：https://github.com/larksuite/oapi-sdk-go-demo
+
+## 加入交流互助群
+
+[单击加入交流互助](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=985nb30c-787a-4fbb-904d-2cf945534078)
+
+## License
+
+MIT

--- a/scene/registration/addons.go
+++ b/scene/registration/addons.go
@@ -1,0 +1,132 @@
+package registration
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+func encodeAddons(addons *AppAddons) (string, error) {
+	payload, err := normalizeAddons(addons)
+	if err != nil {
+		return "", err
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("registration: marshal Addons failed: %w", err)
+	}
+
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := writer.Write(body); err != nil {
+		if closeErr := writer.Close(); closeErr != nil {
+			return "", fmt.Errorf("registration: gzip Addons failed: write: %w; close: %v", err, closeErr)
+		}
+		return "", fmt.Errorf("registration: gzip Addons failed: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("registration: gzip Addons failed: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func normalizeAddons(addons *AppAddons) (map[string]interface{}, error) {
+	if addons == nil {
+		return nil, fmt.Errorf("registration: Addons is required")
+	}
+
+	itemCount := 0
+	payload := make(map[string]interface{})
+
+	scopes, hasScopes, err := normalizeAddonsScopes(addons.Scopes, &itemCount)
+	if err != nil {
+		return nil, err
+	}
+	if hasScopes {
+		payload["scopes"] = scopes
+	}
+
+	events, hasEvents, err := normalizeAddonsEvents(addons.Events, &itemCount)
+	if err != nil {
+		return nil, err
+	}
+	if hasEvents {
+		payload["events"] = events
+	}
+
+	callbacks, hasCallbacks, err := normalizeAddonsCallbacks(addons.Callbacks, &itemCount)
+	if err != nil {
+		return nil, err
+	}
+	if hasCallbacks {
+		payload["callbacks"] = callbacks
+	}
+
+	if itemCount == 0 {
+		return nil, fmt.Errorf("registration: Addons must contain at least one scope, event or callback")
+	}
+	return payload, nil
+}
+
+func normalizeAddonsScopes(scopes AppAddonsScopes, itemCount *int) (map[string][]string, bool, error) {
+	payload := make(map[string][]string)
+	if values, ok, err := normalizeAddonsStringList(scopes.Tenant, "Addons.Scopes.Tenant", itemCount); err != nil {
+		return nil, false, err
+	} else if ok {
+		payload["tenant"] = values
+	}
+	if values, ok, err := normalizeAddonsStringList(scopes.User, "Addons.Scopes.User", itemCount); err != nil {
+		return nil, false, err
+	} else if ok {
+		payload["user"] = values
+	}
+	return payload, len(payload) > 0, nil
+}
+
+func normalizeAddonsEvents(events AppAddonsEvents, itemCount *int) (map[string]interface{}, bool, error) {
+	items := make(map[string][]string)
+	if values, ok, err := normalizeAddonsStringList(events.Items.Tenant, "Addons.Events.Items.Tenant", itemCount); err != nil {
+		return nil, false, err
+	} else if ok {
+		items["tenant"] = values
+	}
+	if values, ok, err := normalizeAddonsStringList(events.Items.User, "Addons.Events.Items.User", itemCount); err != nil {
+		return nil, false, err
+	} else if ok {
+		items["user"] = values
+	}
+	if len(items) == 0 {
+		return nil, false, nil
+	}
+	return map[string]interface{}{
+		"items": items,
+	}, true, nil
+}
+
+func normalizeAddonsCallbacks(callbacks AppAddonsCallbacks, itemCount *int) (map[string][]string, bool, error) {
+	values, ok, err := normalizeAddonsStringList(callbacks.Items, "Addons.Callbacks.Items", itemCount)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	return map[string][]string{
+		"items": values,
+	}, true, nil
+}
+
+func normalizeAddonsStringList(values []string, path string, itemCount *int) ([]string, bool, error) {
+	if values == nil {
+		return nil, false, nil
+	}
+	for idx, value := range values {
+		if value == "" {
+			return nil, true, fmt.Errorf("registration: %s[%d] must be a non-empty string", path, idx)
+		}
+	}
+	*itemCount += len(values)
+	return append([]string(nil), values...), true, nil
+}

--- a/scene/registration/registration.go
+++ b/scene/registration/registration.go
@@ -60,7 +60,7 @@ func RegisterApp(ctx context.Context, opts *Options) (*RegisterAppResult, error)
 		return nil, err
 	}
 
-	qrURL, err := buildQRCodeURL(beginResp.VerificationURIComplete, opts.Source, opts.AppPreset)
+	qrURL, err := buildQRCodeURL(beginResp.VerificationURIComplete, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func normalizedExpireIn(expireIn int) int {
 	return expireIn
 }
 
-func buildQRCodeURL(rawURL, source string, preset *AppPreset) (string, error) {
+func buildQRCodeURL(rawURL string, opts *Options) (string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err
@@ -247,13 +247,29 @@ func buildQRCodeURL(rawURL, source string, preset *AppPreset) (string, error) {
 	query := parsedURL.Query()
 	query.Set("from", "sdk")
 	query.Set("tp", "sdk")
-	if source == "" {
+	if opts.Source == "" {
 		query.Set("source", sdkName)
 	} else {
-		query.Set("source", sdkName+"/"+source)
+		query.Set("source", sdkName+"/"+opts.Source)
 	}
-	if err := applyAppPreset(query, preset); err != nil {
+	if err := applyAppPreset(query, opts.AppPreset); err != nil {
 		return "", err
+	}
+	if opts.Addons != nil {
+		encodedAddons, err := encodeAddons(opts.Addons)
+		if err != nil {
+			return "", err
+		}
+		query.Set("addons", encodedAddons)
+	}
+	if opts.CreateOnly {
+		query.Set("createOnly", "true")
+	}
+	if opts.AppID != "" {
+		if strings.TrimSpace(opts.AppID) == "" {
+			return "", errors.New("registration: Options.AppID must be a non-empty string")
+		}
+		query.Set("clientID", opts.AppID)
 	}
 	parsedURL.RawQuery = query.Encode()
 	return parsedURL.String(), nil

--- a/scene/registration/registration_test.go
+++ b/scene/registration/registration_test.go
@@ -1,8 +1,13 @@
 package registration
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -239,6 +244,127 @@ func TestRegisterAppAppPresetDoesNotInterfereWithSource(t *testing.T) {
 	}
 	if query.Get("name") != "X" {
 		t.Fatalf("unexpected name: %s", query.Get("name"))
+	}
+}
+
+func TestRegisterAppOmitsAddonsCreateOnlyAndAppIDWhenUnset(t *testing.T) {
+	qrURL := captureQRURL(t, Options{})
+	query := qrURL.Query()
+
+	for _, key := range []string{"addons", "createOnly", "clientID"} {
+		if _, ok := query[key]; ok {
+			t.Fatalf("unexpected %s param: %s", key, qrURL.String())
+		}
+	}
+}
+
+func TestRegisterAppAddonsEncodesURLSafeParam(t *testing.T) {
+	addons := &AppAddons{
+		Scopes: AppAddonsScopes{
+			Tenant: []string{"im:message:send_as_bot", "drive:drive.metadata:readonly"},
+			User:   []string{"calendar:calendar:read"},
+		},
+		Events: AppAddonsEvents{
+			Items: AppAddonsEventItems{
+				Tenant: []string{"im.message.receive_v1"},
+				User:   []string{"calendar.calendar.event.changed_v4"},
+			},
+		},
+		Callbacks: AppAddonsCallbacks{
+			Items: []string{"card.action.trigger"},
+		},
+	}
+	qrURL := captureQRURL(t, Options{
+		Addons: addons,
+	})
+	encoded := qrURL.Query().Get("addons")
+
+	if encoded == "" {
+		t.Fatalf("expected addons param: %s", qrURL.String())
+	}
+	if strings.ContainsAny(encoded, "+/=") {
+		t.Fatalf("expected URL-safe base64 without padding, got %q", encoded)
+	}
+	decoded := decodeAddonsParam(t, qrURL)
+	if !reflect.DeepEqual(decoded, *addons) {
+		t.Fatalf("unexpected decoded addons:\nwant: %#v\n got: %#v", *addons, decoded)
+	}
+}
+
+func TestRegisterAppAddonsRejectsEmpty(t *testing.T) {
+	expectOptionsReject(t, Options{
+		Addons: &AppAddons{},
+	}, "Addons must contain at least one scope, event or callback")
+}
+
+func TestRegisterAppAddonsRejectsEmptyItem(t *testing.T) {
+	expectOptionsReject(t, Options{
+		Addons: &AppAddons{
+			Callbacks: AppAddonsCallbacks{
+				Items: []string{"card.action.trigger", ""},
+			},
+		},
+	}, "Addons.Callbacks.Items[1] must be a non-empty string")
+}
+
+func TestRegisterAppCreateOnlySetsParamOnlyWhenTrue(t *testing.T) {
+	enabledURL := captureQRURL(t, Options{
+		CreateOnly: true,
+	})
+	if got := enabledURL.Query().Get("createOnly"); got != "true" {
+		t.Fatalf("unexpected createOnly: %s", got)
+	}
+
+	disabledURL := captureQRURL(t, Options{
+		CreateOnly: false,
+	})
+	if _, ok := disabledURL.Query()["createOnly"]; ok {
+		t.Fatalf("unexpected createOnly param: %s", disabledURL.String())
+	}
+}
+
+func TestRegisterAppAppIDSetsClientID(t *testing.T) {
+	qrURL := captureQRURL(t, Options{
+		AppID: "cli_a1b2c3",
+	})
+
+	if got := qrURL.Query().Get("clientID"); got != "cli_a1b2c3" {
+		t.Fatalf("unexpected clientID: %s", got)
+	}
+}
+
+func TestRegisterAppNewParamsCoexistWithAppPreset(t *testing.T) {
+	qrURL := captureQRURL(t, Options{
+		AppPreset: &AppPreset{
+			Name: "MyApp",
+		},
+		Addons: &AppAddons{
+			Scopes: AppAddonsScopes{
+				Tenant: []string{"im:message:send_as_bot"},
+			},
+		},
+		CreateOnly: true,
+		AppID:      "cli_a1b2c3",
+	})
+	query := qrURL.Query()
+
+	if got := query.Get("name"); got != "MyApp" {
+		t.Fatalf("unexpected name: %s", got)
+	}
+	if got := query.Get("createOnly"); got != "true" {
+		t.Fatalf("unexpected createOnly: %s", got)
+	}
+	if got := query.Get("clientID"); got != "cli_a1b2c3" {
+		t.Fatalf("unexpected clientID: %s", got)
+	}
+	decoded := decodeAddonsParam(t, qrURL)
+	want := AppAddons{
+		Scopes: AppAddonsScopes{
+			Tenant: []string{"im:message:send_as_bot"},
+		},
+	}
+	if !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("unexpected decoded addons:\nwant: %#v\n got: %#v", want, decoded)
 	}
 }
 
@@ -728,6 +854,14 @@ func captureQRURL(t *testing.T, opts Options) *url.URL {
 func expectAppPresetReject(t *testing.T, preset *AppPreset, wantErr string) {
 	t.Helper()
 
+	expectOptionsReject(t, Options{
+		AppPreset: preset,
+	}, wantErr)
+}
+
+func expectOptionsReject(t *testing.T, opts Options, wantErr string) {
+	t.Helper()
+
 	restoreWait := stubWaitForInterval()
 	defer restoreWait()
 
@@ -739,7 +873,7 @@ func expectAppPresetReject(t *testing.T, preset *AppPreset, wantErr string) {
 		case "begin":
 			writeJSON(w, `{"device_code":"dev-1","verification_uri_complete":"https://accounts.feishu.cn/page/launcher","interval":0,"expire_in":600}`)
 		case "poll":
-			t.Fatal("poll should not be called when preset validation fails")
+			t.Fatal("poll should not be called when options validation fails")
 		default:
 			t.Fatalf("unexpected action: %s", r.Form.Get("action"))
 		}
@@ -747,13 +881,11 @@ func expectAppPresetReject(t *testing.T, preset *AppPreset, wantErr string) {
 	defer server.Close()
 
 	calledQRCode := false
-	_, err := RegisterApp(context.Background(), &Options{
-		Domain:    server.URL,
-		AppPreset: preset,
-		OnQRCode: func(info *QRCodeInfo) {
-			calledQRCode = true
-		},
-	})
+	opts.Domain = server.URL
+	opts.OnQRCode = func(info *QRCodeInfo) {
+		calledQRCode = true
+	}
+	_, err := RegisterApp(context.Background(), &opts)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -765,7 +897,41 @@ func expectAppPresetReject(t *testing.T, preset *AppPreset, wantErr string) {
 	}
 }
 
+func decodeAddonsParam(t *testing.T, qrURL *url.URL) AppAddons {
+	t.Helper()
+
+	encoded := qrURL.Query().Get("addons")
+	if encoded == "" {
+		t.Fatalf("missing addons param: %s", qrURL.String())
+	}
+	compressed, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode addons base64 failed: %v", err)
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("create gzip reader failed: %v", err)
+	}
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Fatalf("close gzip reader failed: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read addons gzip body failed: %v", err)
+	}
+	var addons AppAddons
+	if err := json.Unmarshal(body, &addons); err != nil {
+		t.Fatalf("unmarshal addons failed: %v", err)
+	}
+	return addons
+}
+
 func writeJSON(w http.ResponseWriter, body string) {
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(body))
+	if _, err := w.Write([]byte(body)); err != nil {
+		panic("write test JSON response failed: " + err.Error())
+	}
 }

--- a/scene/registration/types.go
+++ b/scene/registration/types.go
@@ -36,6 +36,48 @@ type AppPreset struct {
 	Desc string
 }
 
+// AppAddons contains incremental app config pre-filled into the confirmation
+// page shown after the user opens the QR code URL. Only public scopes, events,
+// and callbacks are supported. Sensitive config must be updated through the
+// application config OpenAPI instead.
+type AppAddons struct {
+	// Scopes contains app-identity and user-identity permission scopes.
+	Scopes AppAddonsScopes `json:"scopes,omitempty"`
+
+	// Events contains app-identity and user-identity event subscriptions.
+	Events AppAddonsEvents `json:"events,omitempty"`
+
+	// Callbacks contains callback names.
+	Callbacks AppAddonsCallbacks `json:"callbacks,omitempty"`
+}
+
+type AppAddonsScopes struct {
+	// Tenant contains app-identity scopes, for example
+	// im:message:send_as_bot.
+	Tenant []string `json:"tenant,omitempty"`
+
+	// User contains user-identity scopes, for example calendar:calendar:read.
+	User []string `json:"user,omitempty"`
+}
+
+type AppAddonsEvents struct {
+	Items AppAddonsEventItems `json:"items,omitempty"`
+}
+
+type AppAddonsEventItems struct {
+	// Tenant contains app-identity events, for example im.message.receive_v1.
+	Tenant []string `json:"tenant,omitempty"`
+
+	// User contains user-identity events, for example
+	// calendar.calendar.event.changed_v4.
+	User []string `json:"user,omitempty"`
+}
+
+type AppAddonsCallbacks struct {
+	// Items contains callback names, for example card.action.trigger.
+	Items []string `json:"items,omitempty"`
+}
+
 type UserInfo struct {
 	OpenID      string
 	TenantBrand string
@@ -52,6 +94,9 @@ type Options struct {
 	Domain         string
 	LarkDomain     string
 	AppPreset      *AppPreset
+	Addons         *AppAddons
+	CreateOnly     bool
+	AppID          string
 	OnQRCode       func(info *QRCodeInfo)
 	OnStatusChange func(info *StatusChangeInfo)
 }


### PR DESCRIPTION
## Summary

- Add `registration.Options` support for `Addons`, `CreateOnly`, and `AppID` when building one-click app registration QR URLs.
- Validate and encode addons as gzip-compressed base64url JSON, matching the Node SDK registration flow.
- Cover the new QR URL parameters with registration unit tests.
- Split the root README into English `README.md` and Chinese `README.zh.md`.

## Validation

- `git diff --check`
- `/usr/local/go/bin/go test -count=1 ./scene/registration`
- `/usr/local/go/bin/go test -count=1 ./...`

## Notes

The real one-click app registration E2E flow was not run because it requires a live environment and manual QR-code authorization.

Change-Id: I9a6cd7d6777d4324ed969bad13c9a36ccf912597