### PR TITLE
fix(ws): synchronize Client config/conn fields to remove data race (#188)

### DIFF
--- a/service/ext/model.go
+++ b/service/ext/model.go
@@ -31,8 +31,8 @@ type AuthenAccessTokenReqBody struct {
 }
 
 type AuthenAccessTokenReqBodyBuilder struct {
-	grantType string `json:"grant_type,omitempty"`
-	code      string `json:"code,omitempty"`
+	grantType string
+	code      string
 }
 
 func NewAuthenAccessTokenReqBodyBuilder() *AuthenAccessTokenReqBodyBuilder {
@@ -124,8 +124,8 @@ type RefreshAuthenAccessTokenReqBody struct {
 }
 
 type RefreshAuthenAccessTokenReqBodyBuilder struct {
-	grantType    string `json:"grant_type,omitempty"`
-	refreshToken string `json:"refresh_token,omitempty"`
+	grantType    string
+	refreshToken string
 }
 
 func NewRefreshAuthenAccessTokenReqBodyBuilder() *RefreshAuthenAccessTokenReqBodyBuilder {
@@ -263,8 +263,8 @@ type CreateFileReqBody struct {
 }
 
 type CreateFileReqBodyBuilder struct {
-	title string `json:"title,omitempty"`
-	type_ string `json:"type,omitempty"`
+	title string
+	type_ string
 }
 
 func NewCreateFileReqBodyBuilder() *CreateFileReqBodyBuilder {

--- a/service/im/v1/ext_model.go
+++ b/service/im/v1/ext_model.go
@@ -268,7 +268,6 @@ func (t *MessageText) AtUser(userId, name string) *MessageText {
 	t.builder.WriteString(name)
 	t.builder.WriteString("</at>")
 	return t
-	return t
 }
 
 func (t *MessageText) AtAll() *MessageText {

--- a/ws/client.go
+++ b/ws/client.go
@@ -231,9 +231,6 @@ func (c *Client) Start(ctx context.Context) (err error) {
 }
 
 func (c *Client) connect(ctx context.Context) (err error) {
-	if c.conn != nil {
-		return
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.conn != nil {
@@ -280,15 +277,17 @@ func (c *Client) reconnect(ctx context.Context) (err error) {
 		c.onReconnecting()
 	}
 
+	reconnectCount, _, reconnectNonce, _ := c.configSnapshot()
+
 	// 首次重连随机抖动
-	if c.reconnectNonce > 0 {
+	if reconnectNonce > 0 {
 		rand.Seed(time.Now().UnixNano())
-		num := rand.Intn(c.reconnectNonce * 1000)
+		num := rand.Intn(reconnectNonce * 1000)
 		time.Sleep(time.Duration(num) * time.Millisecond)
 	}
 
-	if c.reconnectCount >= 0 {
-		for i := 0; i < c.reconnectCount; i++ {
+	if reconnectCount >= 0 {
+		for i := 0; i < reconnectCount; i++ {
 			success, err := c.tryConnect(ctx, i)
 			if success {
 				if c.onReconnected != nil {
@@ -299,9 +298,10 @@ func (c *Client) reconnect(ctx context.Context) (err error) {
 			if err != nil {
 				return err
 			}
-			time.Sleep(c.reconnectInterval)
+			_, reconnectInterval, _, _ := c.configSnapshot()
+			time.Sleep(reconnectInterval)
 		}
-		return fmt.Errorf("unable to connect to server after %d retries", c.reconnectCount)
+		return fmt.Errorf("unable to connect to server after %d retries", reconnectCount)
 	} else {
 		i := 0
 		for {
@@ -315,7 +315,8 @@ func (c *Client) reconnect(ctx context.Context) (err error) {
 			if err != nil {
 				return err
 			}
-			time.Sleep(c.reconnectInterval)
+			_, reconnectInterval, _, _ := c.configSnapshot()
+			time.Sleep(reconnectInterval)
 			i += 1
 		}
 	}
@@ -341,9 +342,6 @@ func (c *Client) tryConnect(ctx context.Context, cnt int) (bool, error) {
 }
 
 func (c *Client) disconnect(ctx context.Context) {
-	if c.conn == nil {
-		return
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.conn == nil {
@@ -466,7 +464,9 @@ func (c *Client) getConnURL(ctx context.Context) (url string, err error) {
 
 	url = endpoint.Url
 	if endpoint.ClientConfig != nil {
-		c.configure(endpoint.ClientConfig)
+		// getConnURL is only ever called from connect, which already holds c.mu;
+		// use the locked variant to avoid self-deadlocking on the non-reentrant mutex.
+		c.configureLocked(endpoint.ClientConfig)
 	}
 
 	return
@@ -502,8 +502,9 @@ func (c *Client) pingLoop(ctx context.Context) {
 	}()
 
 	for {
-		if c.conn != nil {
-			i, _ := strconv.ParseInt(c.serviceID, 10, 32)
+		conn, serviceID := c.connState()
+		if conn != nil {
+			i, _ := strconv.ParseInt(serviceID, 10, 32)
 			frame := NewPingFrame(int32(i))
 			bs, _ := frame.Marshal()
 
@@ -514,7 +515,8 @@ func (c *Client) pingLoop(ctx context.Context) {
 				c.logger.Debug(ctx, c.fmtLog("ping success")...)
 			}
 		}
-		time.Sleep(c.pingInterval)
+		_, _, _, pingInterval := c.configSnapshot()
+		time.Sleep(pingInterval)
 	}
 }
 
@@ -532,12 +534,13 @@ func (c *Client) receiveMessageLoop(ctx context.Context) {
 	}()
 
 	for {
-		if c.conn == nil {
+		conn, _ := c.connState()
+		if conn == nil {
 			c.logger.Error(ctx, c.fmtLog("connection is closed, receive message loop exit")...)
 			return
 		}
 
-		mt, msg, err := c.conn.ReadMessage()
+		mt, msg, err := conn.ReadMessage()
 		if err != nil {
 			c.logger.Error(ctx, c.fmtLog("receive message failed, err: %v", err)...)
 			return
@@ -702,11 +705,39 @@ func (c *Client) fmtLog(format string, i ...interface{}) []interface{} {
 	return log
 }
 
+// configure applies a server-pushed config. It is the entry point for callers
+// that do NOT already hold c.mu (the pong control-frame handler runs in its own
+// goroutine). The connect path holds c.mu while building the URL, so it calls
+// configureLocked directly to avoid re-entering the non-reentrant mutex.
 func (c *Client) configure(conf *ClientConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.configureLocked(conf)
+}
+
+// configureLocked writes the connection-control fields. The caller must hold c.mu.
+func (c *Client) configureLocked(conf *ClientConfig) {
 	c.reconnectCount = conf.ReconnectCount
 	c.reconnectInterval = time.Duration(conf.ReconnectInterval) * time.Second
 	c.reconnectNonce = conf.ReconnectNonce
 	c.pingInterval = time.Duration(conf.PingInterval) * time.Second
+}
+
+// configSnapshot reads the connection-control fields under c.mu and returns a
+// consistent copy, so readers (pingLoop, reconnect) never observe a torn write.
+func (c *Client) configSnapshot() (reconnectCount int, reconnectInterval time.Duration, reconnectNonce int, pingInterval time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reconnectCount, c.reconnectInterval, c.reconnectNonce, c.pingInterval
+}
+
+// connState reads conn/serviceID under c.mu. Callers must release the lock (i.e.
+// use the returned snapshot) before any blocking call such as writeMessage or
+// ReadMessage, since writeMessage takes c.mu again and the mutex is not reentrant.
+func (c *Client) connState() (conn *ws.Conn, serviceID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn, c.serviceID
 }
 
 func parseErr(resp *http.Response) error {

--- a/ws/client_race_test.go
+++ b/ws/client_race_test.go
@@ -1,0 +1,176 @@
+package ws
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// These tests exercise the concurrent read/write paths on the connection-control
+// fields (reconnectCount / reconnectInterval / reconnectNonce / pingInterval /
+// conn / serviceID). They are meant to be run under `go test -race`; the data
+// race only surfaces under the race detector, so a plain run passing is not
+// sufficient evidence the bug is fixed.
+//
+// The reader side goes through two locked snapshot accessors that the fix
+// introduces: configSnapshot() for the four config fields and connState() for
+// conn/serviceID. The writer side is configure(), which must take c.mu.
+
+// setServiceIDLocked writes serviceID under c.mu, standing in for connect()'s
+// in-lock write so the read-path synchronization (connState) is what gets raced.
+func (c *Client) setServiceIDLocked(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.serviceID = id
+}
+
+// newRaceClient builds an in-memory Client without establishing a connection.
+// conn stays nil on purpose: these tests cover the field-synchronization paths,
+// not real dialing. The initial config matches validConfigPayloads[0] so a reader
+// that runs before the first configure() still observes a valid whole-config view.
+func newRaceClient() *Client {
+	p := validConfigPayloads[0]
+	return &Client{
+		reconnectCount:    p.ReconnectCount,
+		reconnectInterval: time.Duration(p.ReconnectInterval) * time.Second,
+		reconnectNonce:    p.ReconnectNonce,
+		pingInterval:      time.Duration(p.PingInterval) * time.Second,
+	}
+}
+
+// validConfigPayloads is the closed set of configs the writer goroutines push.
+// configSnapshot must always read back one of these combinations as a whole —
+// never a torn mix of fields from different writes.
+var validConfigPayloads = []*ClientConfig{
+	{ReconnectCount: -1, ReconnectInterval: 1, ReconnectNonce: 5, PingInterval: 10},
+	{ReconnectCount: 3, ReconnectInterval: 2, ReconnectNonce: 30, PingInterval: 120},
+	{ReconnectCount: 0, ReconnectInterval: 5, ReconnectNonce: 0, PingInterval: 60},
+}
+
+func isValidSnapshot(count int, interval time.Duration, nonce int, ping time.Duration) bool {
+	for _, p := range validConfigPayloads {
+		if count == p.ReconnectCount &&
+			interval == time.Duration(p.ReconnectInterval)*time.Second &&
+			nonce == p.ReconnectNonce &&
+			ping == time.Duration(p.PingInterval)*time.Second {
+			return true
+		}
+	}
+	return false
+}
+
+// configure (writer, models pong config push) racing configSnapshot (reader,
+// models pingLoop/reconnect reading the config fields) must not data-race, and
+// every snapshot must be a consistent whole-config view, never a torn read.
+func TestConfigureAndConfigSnapshotNoRace(t *testing.T) {
+	c := newRaceClient()
+
+	const goroutines = 8
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// writers: push whole ClientConfig values
+	for w := 0; w < goroutines; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				c.configure(validConfigPayloads[(w+i)%len(validConfigPayloads)])
+			}
+		}(w)
+	}
+
+	// readers: take config snapshots and assert each is a consistent whole
+	for r := 0; r < goroutines; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				count, interval, nonce, ping := c.configSnapshot()
+				if !isValidSnapshot(count, interval, nonce, ping) {
+					t.Errorf("torn config snapshot: count=%d interval=%v nonce=%d ping=%v",
+						count, interval, nonce, ping)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// configure racing connState (reader of conn/serviceID, as pingLoop and
+// receiveMessageLoop do) must not data-race. serviceID is written under c.mu in
+// production (inside connect); here a locked white-box helper stands in for that
+// writer so the read path's synchronization is what gets exercised.
+func TestConfigureAndConnStateNoRace(t *testing.T) {
+	c := newRaceClient()
+
+	const goroutines = 8
+	const iterations = 200
+	serviceIDs := []string{"1", "42", "1024", "65535"}
+	var wg sync.WaitGroup
+
+	// config writers
+	for w := 0; w < goroutines; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				c.configure(validConfigPayloads[(w+i)%len(validConfigPayloads)])
+			}
+		}(w)
+	}
+
+	// serviceID writers, mutating under the same lock connect() uses
+	for w := 0; w < goroutines; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				c.setServiceIDLocked(serviceIDs[(w+i)%len(serviceIDs)])
+			}
+		}(w)
+	}
+
+	// conn/serviceID readers
+	for r := 0; r < goroutines; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_, _ = c.connState()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// Single-threaded behavior guard: locking the write path must not change
+// configure's semantics — a snapshot taken right after a configure reads back
+// exactly what was written, with the second-based unit conversion intact.
+func TestConfigureThenSnapshotReadsBackWrittenValues(t *testing.T) {
+	c := newRaceClient()
+
+	c.configure(&ClientConfig{
+		ReconnectCount:    7,
+		ReconnectInterval: 3,
+		ReconnectNonce:    15,
+		PingInterval:      90,
+	})
+
+	count, interval, nonce, ping := c.configSnapshot()
+	if count != 7 {
+		t.Errorf("reconnectCount = %d, want 7", count)
+	}
+	if interval != 3*time.Second {
+		t.Errorf("reconnectInterval = %v, want 3s", interval)
+	}
+	if nonce != 15 {
+		t.Errorf("reconnectNonce = %d, want 15", nonce)
+	}
+	if ping != 90*time.Second {
+		t.Errorf("pingInterval = %v, want 90s", ping)
+	}
+}


### PR DESCRIPTION
## What & Why

Fixes #188 — a data race in `ws.Client` reported by `go test -race` (v3.5.3).

`configure()` writes the connection-control fields (`reconnectCount`, `reconnectInterval`, `reconnectNonce`, `pingInterval`) from the pong control-frame goroutine, while `pingLoop()` / `reconnect()` / `receiveMessageLoop()` read those fields and `conn` / `serviceID` concurrently without synchronization. The existing `c.mu` mutex wasn't applied to these paths.

## Changes

- `configure()` now takes `c.mu`. It's split into `configure()` (acquires the lock, used by the pong path) and `configureLocked()` (assumes the lock is held). `getConnURL` — which runs inside `connect()`'s critical section — calls `configureLocked()` to avoid self-deadlocking on the non-reentrant mutex.
- Added locked snapshot accessors `configSnapshot()` and `connState()`.
- `pingLoop()`, `reconnect()`, and `receiveMessageLoop()` now read a snapshot under `c.mu`, release the lock, then perform the blocking call (`writeMessage` / `time.Sleep` / `ReadMessage`) — never holding the lock across a blocking operation.
- Dropped the racy pre-lock `c.conn` checks in `connect()` / `disconnect()` (double-checked-locking reads); the in-lock checks already guarantee idempotency.

No exported API or behavior changes — purely internal synchronization.

### Incidental cleanup (unrelated to the fix)
To keep `go vet ./...` green for CI: removed vestigial `json` tags on unexported builder fields in `service/ext/model.go`, and removed an unreachable duplicate `return` in `service/im/v1/ext_model.go`. Both are behavior-preserving.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test -race ./ws/...` — pass, including a new `ws/client_race_test.go` that concurrently races `configure()` against the snapshot readers and asserts no torn reads.

## Follow-ups (out of scope; not in the original race report)

- `fmtLog()` reads `c.connID` without the lock — same family of race, but `connID` isn't in this issue's field set and a safe fix must account for `fmtLog` being called both inside and outside the lock.
- `reconnect()` uses the server-pushed `reconnectNonce` in `rand.Intn(reconnectNonce * 1000)` without an upper bound; a large value can overflow and panic. Pre-existing.
