### PR TITLE
feat(registration): support preset flag in app addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,33 @@ if err != nil {
 
 Notes: `Addons` is additive only and cannot remove config from the base template. The SDK validates shape and non-empty strings, but does not validate whether scope, event, or callback names exist.
 
+#### Choosing The Base Template With `Preset`
+
+`AppAddons.Preset` selects the base template for app creation (it is unrelated to `Options.AppPreset`, which pre-fills the app name, description, and avatar):
+
+| Value | Base template | Behavior |
+| ---- | ---- | ---- |
+| unset (`nil`) | Platform default template | Same as before this field existed; the encoded payload carries no `preset` key. |
+| `false` | Minimal base template | The confirmation page shows only the scopes, events, and callbacks declared in `Addons`. |
+| `true` | Platform default template | Explicitly requests the default base, same as unset. |
+
+With `Preset` set to `false`, an `Addons` without any scope, event, or callback is valid — the page still enters the confirmation flow and creates an app with only the minimal base capabilities:
+
+```go
+preset := false
+_, err := registration.RegisterApp(ctx, &registration.Options{
+	Addons: &registration.AppAddons{
+		Preset: &preset,
+	},
+	OnQRCode: func(info *registration.QRCodeInfo) {
+		fmt.Println(info.URL)
+	},
+})
+if err != nil {
+	panic(err)
+}
+```
+
 ### `registration.RegisterApp` Parameters
 
 | Parameter | Description | Type | Required | Default |
@@ -133,6 +160,7 @@ Notes: `Addons` is additive only and cannot remove config from the base template
 | `Options.AppPreset.Name` | App name with `{user}` placeholder support; pass raw value and the SDK encodes it. | `string` | No | - |
 | `Options.AppPreset.Desc` | App description with `{user}` placeholder support; pass raw value and the SDK encodes it. | `string` | No | - |
 | `Options.Addons` | Incremental scopes, events, and callbacks pre-filled into the confirmation page. | `*registration.AppAddons` | No | - |
+| `Options.Addons.Preset` | Base template selector: unset for the platform default template, `false` for the minimal base template (empty increments allowed), `true` for explicitly requesting the default base. | `*bool` | No | - |
 | `Options.Addons.Scopes.Tenant` | App-identity scopes, for example `im:message:send_as_bot`. | `[]string` | No | - |
 | `Options.Addons.Scopes.User` | User-identity scopes, for example `calendar:calendar:read`. | `[]string` | No | - |
 | `Options.Addons.Events.Items.Tenant` | App-identity events, for example `im.message.receive_v1`. | `[]string` | No | - |

--- a/README.zh.md
+++ b/README.zh.md
@@ -120,6 +120,33 @@ if err != nil {
 
 注意：`Addons` 仅支持增量叠加，不支持删除基础模板中的配置；SDK 只校验数据形状和非空字符串，不校验权限点、事件或回调名称是否存在。
 
+#### 通过 `Preset` 选择模板底座
+
+`AppAddons.Preset` 用于选择应用创建的模板底座（与 `Options.AppPreset` 无关，后者只预填应用名称、描述和头像）：
+
+| 取值 | 模板底座 | 行为 |
+| ---- | ---- | ---- |
+| 不设置（`nil`） | 平台默认模板 | 与该字段出现之前完全一致；编码后的 payload 不含 `preset` 键。 |
+| `false` | 最小基础模板 | 确认页只展示 `Addons` 中显式声明的权限、事件和回调。 |
+| `true` | 平台默认模板 | 显式声明使用默认底座，效果与不设置相同。 |
+
+`Preset` 为 `false` 时，允许 `Addons` 不携带任何权限、事件或回调——页面仍会进入确认流程，创建仅含最小底座能力的应用：
+
+```go
+preset := false
+_, err := registration.RegisterApp(ctx, &registration.Options{
+	Addons: &registration.AppAddons{
+		Preset: &preset,
+	},
+	OnQRCode: func(info *registration.QRCodeInfo) {
+		fmt.Println(info.URL)
+	},
+})
+if err != nil {
+	panic(err)
+}
+```
+
 ### `registration.RegisterApp` 参数
 
 | 参数 | 描述 | 类型 | 必填 | 默认值 |
@@ -133,6 +160,7 @@ if err != nil {
 | `Options.AppPreset.Name` | 应用名称，支持 `{user}` 占位符；传原始值，SDK 会编码。 | `string` | 否 | - |
 | `Options.AppPreset.Desc` | 应用描述，支持 `{user}` 占位符；传原始值，SDK 会编码。 | `string` | 否 | - |
 | `Options.Addons` | 增量权限、事件、回调配置，预填到扫码后的确认页，用户确认后生效。 | `*registration.AppAddons` | 否 | - |
+| `Options.Addons.Preset` | 模板底座选择：不设置为平台默认模板；`false` 为最小基础模板（此时允许增量为空）；`true` 为显式声明默认底座。 | `*bool` | 否 | - |
 | `Options.Addons.Scopes.Tenant` | 应用身份权限列表，如 `im:message:send_as_bot`。 | `[]string` | 否 | - |
 | `Options.Addons.Scopes.User` | 用户身份权限列表，如 `calendar:calendar:read`。 | `[]string` | 否 | - |
 | `Options.Addons.Events.Items.Tenant` | 应用身份事件列表，如 `im.message.receive_v1`。 | `[]string` | 否 | - |

--- a/scene/registration/addons.go
+++ b/scene/registration/addons.go
@@ -40,6 +40,10 @@ func normalizeAddons(addons *AppAddons) (map[string]interface{}, error) {
 	itemCount := 0
 	payload := make(map[string]interface{})
 
+	if addons.Preset != nil {
+		payload["preset"] = *addons.Preset
+	}
+
 	scopes, hasScopes, err := normalizeAddonsScopes(addons.Scopes, &itemCount)
 	if err != nil {
 		return nil, err
@@ -64,10 +68,16 @@ func normalizeAddons(addons *AppAddons) (map[string]interface{}, error) {
 		payload["callbacks"] = callbacks
 	}
 
-	if itemCount == 0 {
-		return nil, fmt.Errorf("registration: Addons must contain at least one scope, event or callback")
+	if itemCount == 0 && !isMinimalBase(addons.Preset) {
+		return nil, fmt.Errorf("registration: Addons must contain at least one scope, event or callback, unless Preset is false")
 	}
 	return payload, nil
+}
+
+// isMinimalBase reports whether the addons explicitly select the minimal base
+// template (Preset false), the only case where an empty increment set is valid.
+func isMinimalBase(preset *bool) bool {
+	return preset != nil && !*preset
 }
 
 func normalizeAddonsScopes(scopes AppAddonsScopes, itemCount *int) (map[string][]string, bool, error) {

--- a/scene/registration/registration_test.go
+++ b/scene/registration/registration_test.go
@@ -307,6 +307,188 @@ func TestRegisterAppAddonsRejectsEmptyItem(t *testing.T) {
 	}, "Addons.Callbacks.Items[1] must be a non-empty string")
 }
 
+func TestRegisterAppAddonsOmitsPresetKeyWhenUnset(t *testing.T) {
+	addons := &AppAddons{
+		Scopes: AppAddonsScopes{
+			Tenant: []string{"im:message:send_as_bot"},
+			User:   []string{"calendar:calendar:read"},
+		},
+		Events: AppAddonsEvents{
+			Items: AppAddonsEventItems{
+				Tenant: []string{"im.message.receive_v1"},
+			},
+		},
+		Callbacks: AppAddonsCallbacks{
+			Items: []string{"card.action.trigger"},
+		},
+	}
+	qrURL := captureQRURL(t, Options{
+		Addons: addons,
+	})
+
+	payload := decodeAddonsParamRaw(t, qrURL)
+	if _, ok := payload["preset"]; ok {
+		t.Fatalf("unexpected preset key in payload: %#v", payload)
+	}
+	decoded := decodeAddonsParam(t, qrURL)
+	if !reflect.DeepEqual(decoded, *addons) {
+		t.Fatalf("unexpected decoded addons:\nwant: %#v\n got: %#v", *addons, decoded)
+	}
+}
+
+func TestRegisterAppAddonsPresetFalseAllowsEmptyIncrements(t *testing.T) {
+	qrURL := captureQRURL(t, Options{
+		Addons: &AppAddons{
+			Preset: boolPtr(false),
+		},
+	})
+
+	payload := decodeAddonsParamRaw(t, qrURL)
+	// {"preset":false} alone is a valid payload: the confirmation page renders
+	// a near-empty app on the minimal template base.
+	want := map[string]interface{}{
+		"preset": false,
+	}
+	if !reflect.DeepEqual(payload, want) {
+		t.Fatalf("unexpected payload:\nwant: %#v\n got: %#v", want, payload)
+	}
+}
+
+func TestRegisterAppAddonsPresetFalseCoexistsWithIncrements(t *testing.T) {
+	qrURL := captureQRURL(t, Options{
+		Addons: &AppAddons{
+			Preset: boolPtr(false),
+			Scopes: AppAddonsScopes{
+				Tenant: []string{"im:message:send_as_bot"},
+			},
+		},
+	})
+
+	payload := decodeAddonsParamRaw(t, qrURL)
+	want := map[string]interface{}{
+		"preset": false,
+		"scopes": map[string]interface{}{
+			"tenant": []interface{}{"im:message:send_as_bot"},
+		},
+	}
+	if !reflect.DeepEqual(payload, want) {
+		t.Fatalf("unexpected payload:\nwant: %#v\n got: %#v", want, payload)
+	}
+}
+
+func TestRegisterAppAddonsPresetTrueEncodesPresetKey(t *testing.T) {
+	qrURL := captureQRURL(t, Options{
+		Addons: &AppAddons{
+			Preset: boolPtr(true),
+			Callbacks: AppAddonsCallbacks{
+				Items: []string{"card.action.trigger"},
+			},
+		},
+	})
+
+	payload := decodeAddonsParamRaw(t, qrURL)
+	want := map[string]interface{}{
+		"preset": true,
+		"callbacks": map[string]interface{}{
+			"items": []interface{}{"card.action.trigger"},
+		},
+	}
+	if !reflect.DeepEqual(payload, want) {
+		t.Fatalf("unexpected payload:\nwant: %#v\n got: %#v", want, payload)
+	}
+}
+
+func TestRegisterAppAddonsPresetTrueRejectsEmptyIncrements(t *testing.T) {
+	// Explicit true selects the same default template base as leaving Preset
+	// unset, so an otherwise empty addons payload stays invalid. The spec only
+	// fixes the error prefix; the exact wording is up to the implementation.
+	expectOptionsReject(t, Options{
+		Addons: &AppAddons{
+			Preset: boolPtr(true),
+		},
+	}, "registration:")
+}
+
+func TestRegisterAppAddonsPresetFalseKeepsNonEmptyStringValidation(t *testing.T) {
+	expectOptionsReject(t, Options{
+		Addons: &AppAddons{
+			Preset: boolPtr(false),
+			Callbacks: AppAddonsCallbacks{
+				Items: []string{"card.action.trigger", ""},
+			},
+		},
+	}, "Addons.Callbacks.Items[1] must be a non-empty string")
+}
+
+func TestRegisterAppAddonsPresetFalseFullFlowQRCodeURL(t *testing.T) {
+	restoreWait := stubWaitForInterval()
+	defer restoreWait()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form failed: %v", err)
+		}
+		switch r.Form.Get("action") {
+		case "begin":
+			writeJSON(w, `{"device_code":"device-preset","verification_uri_complete":"https://qr.example.com/scan?ticket=preset-1","interval":0,"expire_in":60}`)
+		case "poll":
+			writeJSON(w, `{"client_id":"cli_preset","client_secret":"sec_preset"}`)
+		default:
+			t.Fatalf("unexpected action: %s", r.Form.Get("action"))
+		}
+	}))
+	defer server.Close()
+
+	var qrInfo *QRCodeInfo
+	result, err := RegisterApp(context.Background(), &Options{
+		Domain: server.URL,
+		Source: "preset-cli",
+		Addons: &AppAddons{
+			Preset: boolPtr(false),
+			Scopes: AppAddonsScopes{
+				Tenant: []string{"im:message:send_as_bot"},
+			},
+		},
+		OnQRCode: func(info *QRCodeInfo) {
+			qrInfo = info
+		},
+	})
+	if err != nil {
+		t.Fatalf("register app failed: %v", err)
+	}
+	if result.ClientID != "cli_preset" || result.ClientSecret != "sec_preset" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if qrInfo == nil {
+		t.Fatal("expected qr info")
+	}
+
+	qrURL, err := url.Parse(qrInfo.URL)
+	if err != nil {
+		t.Fatalf("parse qr url failed: %v", err)
+	}
+	query := qrURL.Query()
+	if query.Get("ticket") != "preset-1" {
+		t.Fatalf("unexpected original query: %s", query.Encode())
+	}
+	if query.Get("from") != "sdk" || query.Get("tp") != "sdk" || query.Get("source") != "go-sdk/preset-cli" {
+		t.Fatalf("unexpected qr query: %s", query.Encode())
+	}
+	if encoded := query.Get("addons"); strings.ContainsAny(encoded, "+/=") {
+		t.Fatalf("expected URL-safe base64 without padding, got %q", encoded)
+	}
+	payload := decodeAddonsParamRaw(t, qrURL)
+	want := map[string]interface{}{
+		"preset": false,
+		"scopes": map[string]interface{}{
+			"tenant": []interface{}{"im:message:send_as_bot"},
+		},
+	}
+	if !reflect.DeepEqual(payload, want) {
+		t.Fatalf("unexpected payload:\nwant: %#v\n got: %#v", want, payload)
+	}
+}
+
 func TestRegisterAppCreateOnlySetsParamOnlyWhenTrue(t *testing.T) {
 	enabledURL := captureQRURL(t, Options{
 		CreateOnly: true,
@@ -900,6 +1082,29 @@ func expectOptionsReject(t *testing.T, opts Options, wantErr string) {
 func decodeAddonsParam(t *testing.T, qrURL *url.URL) AppAddons {
 	t.Helper()
 
+	var addons AppAddons
+	if err := json.Unmarshal(decodeAddonsParamBody(t, qrURL), &addons); err != nil {
+		t.Fatalf("unmarshal addons failed: %v", err)
+	}
+	return addons
+}
+
+// decodeAddonsParamRaw decodes the addons payload into a generic map because a
+// typed AppAddons cannot distinguish an absent key from a zero value, and the
+// preset contract is defined by key presence.
+func decodeAddonsParamRaw(t *testing.T, qrURL *url.URL) map[string]interface{} {
+	t.Helper()
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(decodeAddonsParamBody(t, qrURL), &payload); err != nil {
+		t.Fatalf("unmarshal addons payload failed: %v", err)
+	}
+	return payload
+}
+
+func decodeAddonsParamBody(t *testing.T, qrURL *url.URL) []byte {
+	t.Helper()
+
 	encoded := qrURL.Query().Get("addons")
 	if encoded == "" {
 		t.Fatalf("missing addons param: %s", qrURL.String())
@@ -922,11 +1127,11 @@ func decodeAddonsParam(t *testing.T, qrURL *url.URL) AppAddons {
 	if err != nil {
 		t.Fatalf("read addons gzip body failed: %v", err)
 	}
-	var addons AppAddons
-	if err := json.Unmarshal(body, &addons); err != nil {
-		t.Fatalf("unmarshal addons failed: %v", err)
-	}
-	return addons
+	return body
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func writeJSON(w http.ResponseWriter, body string) {

--- a/scene/registration/types.go
+++ b/scene/registration/types.go
@@ -41,6 +41,19 @@ type AppPreset struct {
 // and callbacks are supported. Sensitive config must be updated through the
 // application config OpenAPI instead.
 type AppAddons struct {
+	// Preset selects the base template for app creation. It is unrelated to
+	// AppPreset, which pre-fills the app name, description and avatar.
+	//
+	//   - nil (default): the platform default template; the encoded payload
+	//     carries no preset key, identical to not setting this field.
+	//   - false: the minimal base template; the confirmation page shows only
+	//     the scopes, events and callbacks declared in this AppAddons. With
+	//     Preset set to false, an AppAddons without any scope, event or
+	//     callback is valid.
+	//   - true: explicitly requests the platform default template, same base
+	//     as nil.
+	Preset *bool `json:"preset,omitempty"`
+
 	// Scopes contains app-identity and user-identity permission scopes.
 	Scopes AppAddonsScopes `json:"scopes,omitempty"`
 


### PR DESCRIPTION
## What

Add an optional `Preset *bool` field to `registration.AppAddons`, allowing callers to
select the base template used by the app-creation confirmation page:

| Value | Base template | Encoded payload |
| ---- | ---- | ---- |
| unset (`nil`) | Platform default template | No `preset` key (byte-identical to previous output) |
| `false` | Minimal base template — the page shows only the scopes/events/callbacks declared in `Addons` | `"preset": false` |
| `true` | Platform default template (explicit) | `"preset": true` |

With `Preset` set to `false`, an `AppAddons` without any scope, event, or callback is
now valid: the encoded payload is exactly `{"preset":false}`, which creates an app with
only the minimal base capabilities. For all other cases the existing "at least one
scope, event or callback" validation still applies.

This aligns the Go SDK with the Node SDK, which already supports `preset?: boolean`.

## Changes

- `scene/registration/types.go`: add `AppAddons.Preset *bool` with three-state semantics
  (documented as unrelated to `AppPreset`, which pre-fills name/desc/avatar).
- `scene/registration/addons.go`: write the top-level `preset` key when set; allow empty
  increments only when `Preset` is `false`; error message updated accordingly.
- `README.md` / `README.zh.md`: document the new field with a minimal-base example.

## Compatibility

Purely additive. When `Preset` is unset, the encoded `addons` parameter is byte-identical
to the previous release, so existing callers are unaffected. The registration begin/poll
flow is untouched.

## Tests

- Unit tests cover the full behavior matrix: key omitted when unset, `{"preset":false}`
  with empty increments, preset coexisting with increments, explicit `true`/unset with
  empty increments still rejected, string validation unaffected, and an end-to-end
  QR-URL decode assertion through `RegisterApp`.
- `go vet` and the full `scene/registration` suite pass.